### PR TITLE
Fix image load path during dev

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,7 +17,8 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8080'
+      '/api': 'http://localhost:8080',
+      '/images': 'http://localhost:8080'
     }
   },
 })


### PR DESCRIPTION
## Summary
- ensure Vite proxies `/images` to the backend so preview works

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870ad7ae2b4833284026f19712a2b39