### PR TITLE
Update model cards and version info

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -92,10 +92,11 @@ func GetModelVersions(c *gin.Context) {
 		}
 
 		versions = append(versions, VersionInfo{
-			ID:        ver.ID,
-			Name:      ver.Name,
-			BaseModel: ver.BaseModel,
-			SizeKB:    sizeKB,
+			ID:           ver.ID,
+			Name:         ver.Name,
+			BaseModel:    ver.BaseModel,
+			SizeKB:       sizeKB,
+			TrainedWords: ver.TrainedWords,
 		})
 	}
 

--- a/backend/api/types.go
+++ b/backend/api/types.go
@@ -44,8 +44,9 @@ type ModelImage struct {
 // It contains the basic fields required for display and selection when downloading
 // a specific model version.
 type VersionInfo struct {
-	ID        int     `json:"id"`
-	Name      string  `json:"name"`
-	BaseModel string  `json:"baseModel"`
-	SizeKB    float64 `json:"sizeKB"`
+	ID           int      `json:"id"`
+	Name         string   `json:"name"`
+	BaseModel    string   `json:"baseModel"`
+	SizeKB       float64  `json:"sizeKB"`
+	TrainedWords []string `json:"trainedWords"`
 }


### PR DESCRIPTION
## Summary
- show trainedWords and base model in API responses
- display each version on its own card and include trained words
- show file sizes in MB
- minor UI updates

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870b119f54c8332b76cfc8de13f7886