### PR TITLE
Add model detail page

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -22,6 +22,24 @@ func GetModels(c *gin.Context) {
 	c.JSON(200, modelsList)
 }
 
+// GetModel returns a single model by ID with its versions
+func GetModel(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid model ID"})
+		return
+	}
+
+	var model models.Model
+	if err := database.DB.Preload("Versions").First(&model, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Model not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, model)
+}
+
 func SyncCivitModels(c *gin.Context) {
 	apiKey := os.Getenv("CIVIT_API_KEY")
 	items, err := FetchCivitModels(apiKey)

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,6 +27,7 @@ func main() {
 	apiGroup := r.Group("/api")
 	{
 		apiGroup.GET("/models", api.GetModels)
+		apiGroup.GET("/models/:id", api.GetModel)
 		apiGroup.DELETE("/models/:id", api.DeleteModel)
 		apiGroup.POST("/sync", api.SyncCivitModels)
 		apiGroup.POST("/sync/:id", api.SyncCivitModelByID)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.10.0",
-        "vue": "^3.5.17"
+        "vue": "^3.5.17",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1728,6 +1729,12 @@
         "@vue/compiler-dom": "3.5.17",
         "@vue/shared": "3.5.17"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/devtools-core": {
       "version": "7.7.7",
@@ -4290,6 +4297,21 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "axios": "^1.10.0",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,11 @@
 <template>
   <div class="app">
     <h1>📦 Local CivitAI Model Manager</h1>
-    <ModelList />
+    <router-view />
   </div>
 </template>
 
-<script setup>
-import ModelList from './components/ModelList.vue'
-</script>
+<script setup></script>
 
 <style>
 body {

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="detail">
+    <button @click="goBack">⬅ Back</button>
+    <h2>{{ model.name }}</h2>
+    <img
+      v-if="imageUrl"
+      :src="imageUrl"
+      :width="model.imageWidth"
+      :height="model.imageHeight"
+    />
+    <div v-if="model.description" v-html="model.description"></div>
+    <p v-if="model.tags">Tags: {{ model.tags.split(",").join(", ") }}</p>
+    <p>Type: {{ model.type }}</p>
+    <p>NSFW: {{ model.nsfw }}</p>
+    <p>Created: {{ model.createdAt }}</p>
+    <p>Updated: {{ model.updatedAt }}</p>
+    <h3>Versions</h3>
+    <ul>
+      <li v-for="v in model.versions" :key="v.ID">
+        {{ v.name }} - {{ v.baseModel }} -
+        <span v-if="v.sizeKB">{{ (v.sizeKB / 1024).toFixed(2) }} MB</span>
+      </li>
+    </ul>
+    <button @click="deleteModel">🗑 Delete</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from "vue";
+import { useRouter, useRoute } from "vue-router";
+import axios from "axios";
+
+const router = useRouter();
+const route = useRoute();
+const model = ref({});
+
+const imageUrl = computed(() => {
+  if (!model.value.imagePath) return null;
+  return model.value.imagePath.replace(/^.*\/backend\/images/, "/images");
+});
+
+const fetchModel = async () => {
+  const { id } = route.params;
+  const res = await axios.get(`/api/models/${id}`);
+  model.value = res.data;
+};
+
+onMounted(fetchModel);
+
+const deleteModel = async () => {
+  if (!confirm("Delete this model and all files?")) return;
+  await axios.delete(`/api/models/${route.params.id}`);
+  router.push("/");
+};
+
+const goBack = () => {
+  router.push("/");
+};
+</script>
+
+<style scoped>
+.detail {
+  padding: 1rem;
+}
+img {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 1rem;
+}
+</style>

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -60,12 +60,16 @@
         Size: {{ (card.version.sizeKB / 1024).toFixed(2) }} MB
       </p>
       <button @click="deleteVersion(card.version.ID)">🗑 Delete</button>
+      <button v-if="card.version.filePath" @click="goToModel(card.model.ID)">
+        ℹ️ More details
+      </button>
     </div>
   </div>
 </template>
 
 <script setup>
 import { ref, computed, onMounted } from "vue";
+import { useRouter } from "vue-router";
 import axios from "axios";
 
 const models = ref([]);
@@ -74,6 +78,7 @@ const modelUrl = ref("");
 const versions = ref([]);
 const selectedVersionId = ref("");
 const loading = ref(false);
+const router = useRouter();
 
 const fetchModels = async () => {
   const res = await axios.get("/api/models");
@@ -168,6 +173,10 @@ const deleteVersion = async (id) => {
   if (!confirm("Delete this version and all files?")) return;
   await axios.delete(`/api/versions/${id}`);
   await fetchModels();
+};
+
+const goToModel = (id) => {
+  router.push(`/model/${id}`);
 };
 </script>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,5 @@
-import { createApp } from 'vue'
-import App from './App.vue'
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount("#app");

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,0 +1,15 @@
+import { createRouter, createWebHashHistory } from "vue-router";
+import ModelList from "./components/ModelList.vue";
+import ModelDetail from "./components/ModelDetail.vue";
+
+const routes = [
+  { path: "/", component: ModelList },
+  { path: "/model/:id", component: ModelDetail, props: true },
+];
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes,
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- allow fetching a single model with new API endpoint
- wire new endpoint in main.go
- install `vue-router`
- add router and ModelDetail component
- add More Details button in ModelList
- render router-view in App

## Testing
- `npm run format`
- `npm run lint`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6873d0c69c708332969d1c5a527e3755