### PR TITLE
Improve model version detail view

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -33,6 +33,7 @@ func main() {
 		apiGroup.POST("/sync/:id", api.SyncCivitModelByID)
 		apiGroup.POST("/sync/version/:versionId", api.SyncVersionByID)
 		apiGroup.GET("/model/:id/versions", api.GetModelVersions)
+		apiGroup.GET("/versions/:id", api.GetVersion)
 		apiGroup.DELETE("/versions/:id", api.DeleteVersion)
 	}
 

--- a/backend/models/version.go
+++ b/backend/models/version.go
@@ -12,6 +12,7 @@ type Version struct {
 	EarlyAccessTimeFrame int     `json:"earlyAccessTimeFrame"`
 	SizeKB               float64 `json:"sizeKB"`
 	TrainedWords         string  `json:"trainedWords"`
+	ModelURL             string  `json:"modelUrl"`
 	ImagePath            string  `json:"imagePath"`
 	FilePath             string  `json:"filePath"`
 }

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -60,7 +60,10 @@
         Size: {{ (card.version.sizeKB / 1024).toFixed(2) }} MB
       </p>
       <button @click="deleteVersion(card.version.ID)">🗑 Delete</button>
-      <button v-if="card.version.filePath" @click="goToModel(card.model.ID)">
+      <button
+        v-if="card.version.filePath"
+        @click="goToModel(card.model.ID, card.version.ID)"
+      >
         ℹ️ More details
       </button>
     </div>
@@ -175,8 +178,8 @@ const deleteVersion = async (id) => {
   await fetchModels();
 };
 
-const goToModel = (id) => {
-  router.push(`/model/${id}`);
+const goToModel = (modelId, versionId) => {
+  router.push(`/model/${modelId}/version/${versionId}`);
 };
 </script>
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -4,7 +4,11 @@ import ModelDetail from "./components/ModelDetail.vue";
 
 const routes = [
   { path: "/", component: ModelList },
-  { path: "/model/:id", component: ModelDetail, props: true },
+  {
+    path: "/model/:modelId/version/:versionId",
+    component: ModelDetail,
+    props: true,
+  },
 ];
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- add `modelUrl` field to versions
- store model page URL when syncing versions
- expose GET `/api/versions/:id`
- route ModelDetail to `/model/:modelId/version/:versionId`
- update ModelList to link to version detail page
- show selected version metadata on ModelDetail page

## Testing
- `npx prettier --write frontend/src/router.js frontend/src/components/ModelList.vue frontend/src/components/ModelDetail.vue`
- `npm run lint`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6873d7aaaaa08332807b075abfcac870