### PR TITLE
Add edit mode to ModelDetails

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -386,3 +386,83 @@ func DeleteVersion(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Version deleted"})
 }
+
+// UpdateModel updates an existing model with new values
+func UpdateModel(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid model ID"})
+		return
+	}
+
+	var model models.Model
+	if err := database.DB.First(&model, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Model not found"})
+		return
+	}
+
+	var input models.Model
+	if err := c.BindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	model.Name = input.Name
+	model.Type = input.Type
+	model.Tags = input.Tags
+	model.Nsfw = input.Nsfw
+	model.Description = input.Description
+	model.CreatedAt = input.CreatedAt
+	model.UpdatedAt = input.UpdatedAt
+	model.ImagePath = input.ImagePath
+	model.FilePath = input.FilePath
+	model.ImageWidth = input.ImageWidth
+	model.ImageHeight = input.ImageHeight
+
+	if err := database.DB.Save(&model).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update model"})
+		return
+	}
+
+	c.JSON(http.StatusOK, model)
+}
+
+// UpdateVersion updates an existing version with new values
+func UpdateVersion(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid version ID"})
+		return
+	}
+
+	var version models.Version
+	if err := database.DB.First(&version, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	var input models.Version
+	if err := c.BindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	version.Name = input.Name
+	version.BaseModel = input.BaseModel
+	version.CreatedAt = input.CreatedAt
+	version.EarlyAccessTimeFrame = input.EarlyAccessTimeFrame
+	version.SizeKB = input.SizeKB
+	version.TrainedWords = input.TrainedWords
+	version.ModelURL = input.ModelURL
+	version.ImagePath = input.ImagePath
+	version.FilePath = input.FilePath
+
+	if err := database.DB.Save(&version).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update version"})
+		return
+	}
+
+	c.JSON(http.StatusOK, version)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -28,12 +28,14 @@ func main() {
 	{
 		apiGroup.GET("/models", api.GetModels)
 		apiGroup.GET("/models/:id", api.GetModel)
+		apiGroup.PUT("/models/:id", api.UpdateModel)
 		apiGroup.DELETE("/models/:id", api.DeleteModel)
 		apiGroup.POST("/sync", api.SyncCivitModels)
 		apiGroup.POST("/sync/:id", api.SyncCivitModelByID)
 		apiGroup.POST("/sync/version/:versionId", api.SyncVersionByID)
 		apiGroup.GET("/model/:id/versions", api.GetModelVersions)
 		apiGroup.GET("/versions/:id", api.GetVersion)
+		apiGroup.PUT("/versions/:id", api.UpdateVersion)
 		apiGroup.DELETE("/versions/:id", api.DeleteVersion)
 	}
 

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -1,64 +1,133 @@
 <template>
   <div class="p-4">
-    <button @click="goBack" class="btn btn-secondary mb-2">⬅ Back</button>
-    <h2 class="h4 fw-bold">{{ model.name }}</h2>
-    <h3 v-if="version.name" class="fs-5 mb-2">{{ version.name }}</h3>
-    <img
-      v-if="imageUrl"
-      :src="imageUrl"
-      :width="model.imageWidth"
-      :height="model.imageHeight"
-      class="img-fluid mb-4"
-    />
-    <div v-if="model.description" v-html="model.description" class="mb-4"></div>
-    <h3 class="fs-5 fw-semibold">Meta</h3>
-    <table class="table mt-4">
-      <tbody>
-        <tr v-if="model.tags">
-          <th>Tags</th>
-          <td>{{ model.tags.split(",").join(", ") }}</td>
-        </tr>
-        <tr>
-          <th>Type</th>
-          <td>{{ model.type }}</td>
-        </tr>
-        <tr>
-          <th>NSFW</th>
-          <td>{{ model.nsfw }}</td>
-        </tr>
-        <tr>
-          <th>Created</th>
-          <td>{{ model.createdAt }}</td>
-        </tr>
-        <tr>
-          <th>Updated</th>
-          <td>{{ model.updatedAt }}</td>
-        </tr>
-        <tr>
-          <th>Base Model</th>
-          <td>{{ version.baseModel }}</td>
-        </tr>
-        <tr v-if="version.trainedWords">
-          <th>Trained Words</th>
-          <td>{{ version.trainedWords.split(",").join(", ") }}</td>
-        </tr>
-        <tr v-if="version.filePath">
-          <th>File</th>
-          <td>{{ fileName }}</td>
-        </tr>
-        <tr v-if="version.sizeKB">
-          <th>Size</th>
-          <td>{{ (version.sizeKB / 1024).toFixed(2) }} MB</td>
-        </tr>
-        <tr v-if="version.modelUrl">
-          <th>Model URL</th>
-          <td>
-            <a :href="version.modelUrl" target="_blank">View on CivitAI</a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <button @click="deleteVersion" class="btn btn-danger mt-4">🗑 Delete Version</button>
+    <div class="mb-2 d-flex gap-2">
+      <button @click="goBack" class="btn btn-secondary">⬅ Back</button>
+      <button
+        v-if="!isEditing"
+        @click="startEdit"
+        class="btn btn-primary"
+      >
+        ✏️ Edit
+      </button>
+      <div v-else class="d-flex gap-2">
+        <button @click="saveEdit" class="btn btn-primary">💾 Save</button>
+        <button @click="cancelEdit" class="btn btn-secondary">Cancel</button>
+      </div>
+    </div>
+    <div v-if="!isEditing">
+      <h2 class="h4 fw-bold">{{ model.name }}</h2>
+      <h3 v-if="version.name" class="fs-5 mb-2">{{ version.name }}</h3>
+      <img
+        v-if="imageUrl"
+        :src="imageUrl"
+        :width="model.imageWidth"
+        :height="model.imageHeight"
+        class="img-fluid mb-4"
+      />
+      <div v-if="model.description" v-html="model.description" class="mb-4"></div>
+      <h3 class="fs-5 fw-semibold">Meta</h3>
+      <table class="table mt-4">
+        <tbody>
+          <tr v-if="model.tags">
+            <th>Tags</th>
+            <td>{{ model.tags.split(",").join(", ") }}</td>
+          </tr>
+          <tr>
+            <th>Type</th>
+            <td>{{ model.type }}</td>
+          </tr>
+          <tr>
+            <th>NSFW</th>
+            <td>{{ model.nsfw }}</td>
+          </tr>
+          <tr>
+            <th>Created</th>
+            <td>{{ model.createdAt }}</td>
+          </tr>
+          <tr>
+            <th>Updated</th>
+            <td>{{ model.updatedAt }}</td>
+          </tr>
+          <tr>
+            <th>Base Model</th>
+            <td>{{ version.baseModel }}</td>
+          </tr>
+          <tr v-if="version.trainedWords">
+            <th>Trained Words</th>
+            <td>{{ version.trainedWords.split(",").join(", ") }}</td>
+          </tr>
+          <tr v-if="version.filePath">
+            <th>File</th>
+            <td>{{ fileName }}</td>
+          </tr>
+          <tr v-if="version.sizeKB">
+            <th>Size</th>
+            <td>{{ (version.sizeKB / 1024).toFixed(2) }} MB</td>
+          </tr>
+          <tr v-if="version.modelUrl">
+            <th>Model URL</th>
+            <td>
+              <a :href="version.modelUrl" target="_blank">View on CivitAI</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <button @click="deleteVersion" class="btn btn-danger mt-4">🗑 Delete Version</button>
+    </div>
+    <div v-else>
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input v-model="model.name" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Version Name</label>
+        <input v-model="version.name" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Tags</label>
+        <input v-model="model.tags" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Type</label>
+        <input v-model="model.type" class="form-control" />
+      </div>
+      <div class="form-check mb-3">
+        <input type="checkbox" class="form-check-input" id="nsfw" v-model="model.nsfw" />
+        <label class="form-check-label" for="nsfw">NSFW</label>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Description</label>
+        <textarea v-model="model.description" class="form-control" rows="3"></textarea>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Created</label>
+        <input v-model="model.createdAt" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Updated</label>
+        <input v-model="model.updatedAt" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Base Model</label>
+        <input v-model="version.baseModel" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Trained Words</label>
+        <input v-model="version.trainedWords" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">File Path</label>
+        <input v-model="version.filePath" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Size (KB)</label>
+        <input v-model.number="version.sizeKB" type="number" class="form-control" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Model URL</label>
+        <input v-model="version.modelUrl" class="form-control" />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -71,6 +140,7 @@ const router = useRouter();
 const route = useRoute();
 const model = ref({});
 const version = ref({});
+const isEditing = ref(false);
 
 const imageUrl = computed(() => {
   const path = version.value.imagePath || model.value.imagePath;
@@ -96,6 +166,22 @@ const deleteVersion = async () => {
   if (!confirm("Delete this version and all files?")) return;
   await axios.delete(`/api/versions/${route.params.versionId}`);
   router.push("/");
+};
+
+const startEdit = () => {
+  isEditing.value = true;
+};
+
+const cancelEdit = async () => {
+  isEditing.value = false;
+  await fetchData();
+};
+
+const saveEdit = async () => {
+  await axios.put(`/api/models/${model.value.ID}`, model.value);
+  await axios.put(`/api/versions/${version.value.ID}`, version.value);
+  isEditing.value = false;
+  await fetchData();
 };
 
 const goBack = () => {


### PR DESCRIPTION
## Summary
- implement `UpdateModel` and `UpdateVersion` API endpoints
- expose new update routes in the backend router
- add editing UI to `ModelDetail.vue` with Save and Cancel buttons

## Testing
- `go vet ./...`
- `go build ./...`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687439d7f5ec8332b8d977bd6ec55b32