### PR TITLE
Remove timestamp fields, sort versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,3 @@ This is a simple desktop application to download and manage models for local ima
 - Settings
     - Move Civitai API key to setting stored in the database
     - Add setting for the models folder location
-- Cleanup
-    - Remove createdAt and updatedAt fields from the application

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -172,8 +172,6 @@ func SyncVersionByID(c *gin.Context) {
 			Type:        modelData.Type,
 			Tags:        strings.Join(modelData.Tags, ","),
 			Description: modelData.Description,
-			CreatedAt:   modelData.Created,
-			UpdatedAt:   modelData.Updated,
 		}
 		database.DB.Create(&model)
 	}
@@ -189,7 +187,6 @@ func SyncVersionByID(c *gin.Context) {
 		VersionID:            verData.ID,
 		Name:                 verData.Name,
 		BaseModel:            verData.BaseModel,
-		CreatedAt:            verData.Created,
 		EarlyAccessTimeFrame: verData.EarlyAccessTimeFrame,
 		SizeKB:               verData.ModelFiles[0].SizeKB,
 		TrainedWords:         strings.Join(verData.TrainedWords, ","),
@@ -243,7 +240,6 @@ func SyncVersionByID(c *gin.Context) {
 		VersionID:            verData.ID,
 		Name:                 verData.Name,
 		BaseModel:            verData.BaseModel,
-		CreatedAt:            verData.Created,
 		EarlyAccessTimeFrame: verData.EarlyAccessTimeFrame,
 		SizeKB:               verData.ModelFiles[0].SizeKB,
 		TrainedWords:         strings.Join(verData.TrainedWords, ","),
@@ -267,8 +263,6 @@ func processModels(items []CivitModel, apiKey string) {
 				Type:        item.Type,
 				Tags:        strings.Join(item.Tags, ","),
 				Description: item.Description,
-				CreatedAt:   item.Created,
-				UpdatedAt:   item.Updated,
 			}
 			database.DB.Create(&existing)
 		}
@@ -299,7 +293,6 @@ func processModels(items []CivitModel, apiKey string) {
 				VersionID:            verData.ID,
 				Name:                 verData.Name,
 				BaseModel:            verData.BaseModel,
-				CreatedAt:            verData.Created,
 				EarlyAccessTimeFrame: verData.EarlyAccessTimeFrame,
 				SizeKB:               verData.ModelFiles[0].SizeKB,
 				TrainedWords:         strings.Join(verData.TrainedWords, ","),
@@ -497,8 +490,6 @@ func UpdateModel(c *gin.Context) {
 	model.Tags = input.Tags
 	model.Nsfw = input.Nsfw
 	model.Description = input.Description
-	model.CreatedAt = input.CreatedAt
-	model.UpdatedAt = input.UpdatedAt
 	model.ImagePath = input.ImagePath
 	model.FilePath = input.FilePath
 	model.ImageWidth = input.ImageWidth
@@ -535,7 +526,6 @@ func UpdateVersion(c *gin.Context) {
 
 	version.Name = input.Name
 	version.BaseModel = input.BaseModel
-	version.CreatedAt = input.CreatedAt
 	version.EarlyAccessTimeFrame = input.EarlyAccessTimeFrame
 	version.SizeKB = input.SizeKB
 	version.TrainedWords = input.TrainedWords

--- a/backend/models/model.go
+++ b/backend/models/model.go
@@ -10,8 +10,6 @@ type Model struct {
 	Tags        string `json:"tags"`
 	Nsfw        bool   `gorm:"column:nsfw" json:"nsfw"`
 	Description string `json:"description"`
-	CreatedAt   string `json:"createdAt"`
-	UpdatedAt   string `json:"updatedAt"`
 
 	// Local paths
 	ImagePath string `json:"imagePath"`

--- a/backend/models/version.go
+++ b/backend/models/version.go
@@ -8,7 +8,6 @@ type Version struct {
 	VersionID            int     `gorm:"uniqueIndex" json:"versionId"`
 	Name                 string  `json:"name"`
 	BaseModel            string  `json:"baseModel"`
-	CreatedAt            string  `json:"createdAt"`
 	EarlyAccessTimeFrame int     `json:"earlyAccessTimeFrame"`
 	SizeKB               float64 `json:"sizeKB"`
 	TrainedWords         string  `json:"trainedWords"`

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="px-4 container">
-    <div
-      class="mb-2 d-flex gap-2 pb-2"
-      v-if="!isEditing"
-    >
+    <div class="mb-2 d-flex gap-2 pb-2" v-if="!isEditing">
       <button @click="goBack" class="btn btn-secondary">Back</button>
       <button @click="startEdit" class="btn btn-primary">Edit</button>
-      <button @click="deleteVersion" class="btn btn-danger ms-auto">Delete</button>
+      <button @click="deleteVersion" class="btn btn-danger ms-auto">
+        Delete
+      </button>
     </div>
     <div v-else class="mb-2 d-flex gap-2 pb-2">
       <button @click="cancelEdit" class="btn btn-secondary">Cancel</button>
@@ -39,14 +38,6 @@
               <tr>
                 <th>NSFW</th>
                 <td>{{ model.nsfw }}</td>
-              </tr>
-              <tr>
-                <th>Created</th>
-                <td>{{ model.createdAt }}</td>
-              </tr>
-              <tr>
-                <th>Updated</th>
-                <td>{{ model.updatedAt }}</td>
               </tr>
               <tr>
                 <th>Base Model</th>
@@ -135,14 +126,6 @@
       <div class="mb-3">
         <label class="form-label">Description</label>
         <div ref="editor" style="height: 200px"></div>
-      </div>
-      <div class="mb-3">
-        <label class="form-label">Created</label>
-        <input v-model="model.createdAt" class="form-control" />
-      </div>
-      <div class="mb-3">
-        <label class="form-label">Updated</label>
-        <input v-model="model.updatedAt" class="form-control" />
       </div>
       <div class="mb-3">
         <label class="form-label">Base Model</label>

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -3,19 +3,19 @@
     <div class="row">
       <div class="col-md-6 d-flex align-content-start flex-wrap gap-2">
         <input
-        v-model="search"
-        placeholder="Search models..."
-        class="form-control w-200 flex-grow-1"
-        style="min-width: 200px"
+          v-model="search"
+          placeholder="Search models..."
+          class="form-control w-200 flex-grow-1"
+          style="min-width: 200px"
         />
 
         <input
-        v-model="tagsSearch"
-        placeholder="Search tags (comma separated)"
-        class="form-control"
-        style="min-width: 200px"
+          v-model="tagsSearch"
+          placeholder="Search tags (comma separated)"
+          class="form-control"
+          style="min-width: 200px"
         />
-        
+
         <select
           v-model="selectedBaseModel"
           class="form-select"
@@ -37,7 +37,7 @@
             {{ t }}
           </option>
         </select>
-        
+
         <div class="form-check form-switch">
           <input
             type="checkbox"
@@ -63,7 +63,7 @@
           :disabled="loading || !modelUrl"
           class="btn btn-secondary"
         >
-        Load Versions
+          Load Versions
         </button>
 
         <!-- Version selector -->
@@ -87,7 +87,11 @@
           :disabled="loading"
           class="btn btn-primary"
         >
-          <span v-if="loading" class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+          <span
+            v-if="loading"
+            class="spinner-border spinner-border-sm"
+            aria-hidden="true"
+          ></span>
           <span v-if="loading" role="status" class="ps-2">Downloading...</span>
           <span v-else>Download</span>
         </button>
@@ -266,24 +270,26 @@ const filteredModels = computed(() => {
 });
 
 const versionCards = computed(() => {
-  return filteredModels.value.flatMap((model) =>
-    model.versions
-      .filter(
-        (v) =>
-          !selectedBaseModel.value || v.baseModel === selectedBaseModel.value,
-      )
-      .map((v) => {
-        let trained = v.trainedWords;
-        if (typeof trained === "string") {
-          trained = trained ? trained.split(",") : [];
-        }
-        return {
-          model,
-          version: { ...v, trainedWordsArr: trained },
-          imageUrl: v.imageUrl || model.imageUrl,
-        };
-      }),
-  );
+  return filteredModels.value
+    .flatMap((model) =>
+      model.versions
+        .filter(
+          (v) =>
+            !selectedBaseModel.value || v.baseModel === selectedBaseModel.value,
+        )
+        .map((v) => {
+          let trained = v.trainedWords;
+          if (typeof trained === "string") {
+            trained = trained ? trained.split(",") : [];
+          }
+          return {
+            model,
+            version: { ...v, trainedWordsArr: trained },
+            imageUrl: v.imageUrl || model.imageUrl,
+          };
+        }),
+    )
+    .sort((a, b) => b.version.ID - a.version.ID);
 });
 
 const extractModelId = (url) => {


### PR DESCRIPTION
## Summary
- drop custom `createdAt` and `updatedAt` fields from backend models
- remove timestamp usage in API handlers and frontend views
- clean up README todo
- display version cards sorted by latest first

## Testing
- `go build ./...`
- `npm run lint`
- `npm run format`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874b362609483329ea979ee184b248b