### PR TITLE
Add refresh endpoints

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -535,3 +535,142 @@ func UpdateVersion(c *gin.Context) {
 
 	c.JSON(http.StatusOK, version)
 }
+
+// RefreshVersion pulls updated data from CivitAI for the specified version.
+// The fields query parameter controls which parts to update. Acceptable values
+// are comma-separated list of "metadata", "description", and "images". The
+// value "all" updates everything.
+func RefreshVersion(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid version ID"})
+		return
+	}
+
+	var version models.Version
+	if err := database.DB.Preload("Images").First(&version, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	var model models.Model
+	if err := database.DB.First(&model, version.ModelID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Model not found"})
+		return
+	}
+
+	fields := c.DefaultQuery("fields", "all")
+	fields = strings.ToLower(fields)
+	updateMeta := false
+	updateDesc := false
+	updateImages := false
+	if fields == "all" || fields == "" {
+		updateMeta = true
+		updateDesc = true
+		updateImages = true
+	} else {
+		for _, f := range strings.Split(fields, ",") {
+			switch strings.TrimSpace(f) {
+			case "metadata":
+				updateMeta = true
+			case "description":
+				updateDesc = true
+			case "images":
+				updateImages = true
+			}
+		}
+	}
+
+	apiKey := os.Getenv("CIVIT_API_KEY")
+	modelData, err := FetchCivitModel(apiKey, model.CivitID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch model"})
+		return
+	}
+	verData, err := FetchModelVersion(apiKey, version.VersionID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch version"})
+		return
+	}
+
+	if updateMeta {
+		version.Name = verData.Name
+		version.BaseModel = verData.BaseModel
+		version.EarlyAccessTimeFrame = verData.EarlyAccessTimeFrame
+		if len(verData.ModelFiles) > 0 {
+			version.SizeKB = verData.ModelFiles[0].SizeKB
+		}
+		version.TrainedWords = strings.Join(verData.TrainedWords, ",")
+		version.Nsfw = modelData.Nsfw
+		version.Type = modelData.Type
+		version.Tags = strings.Join(modelData.Tags, ",")
+		version.Mode = modelData.Mode
+		version.ModelURL = fmt.Sprintf("https://civitai.com/models/%d?modelVersionId=%d", verData.ModelID, verData.ID)
+
+		model.Name = modelData.Name
+		model.Type = modelData.Type
+		model.Tags = strings.Join(modelData.Tags, ",")
+		model.Nsfw = modelData.Nsfw
+	}
+
+	if updateDesc {
+		model.Description = modelData.Description
+		version.Description = modelData.Description
+	}
+
+	if updateImages {
+		if version.ImagePath != "" {
+			os.Remove(version.ImagePath)
+		}
+		var imgs []models.VersionImage
+		database.DB.Where("version_id = ?", version.ID).Find(&imgs)
+		for _, img := range imgs {
+			if img.Path != "" {
+				os.Remove(img.Path)
+			}
+		}
+		database.DB.Where("version_id = ?", version.ID).Delete(&models.VersionImage{})
+
+		var imagePath string
+		var imgW, imgH int
+		for idx, img := range verData.Images {
+			imageURL := img.URL
+			if imageURL == "" {
+				imageURL = img.URLSmall
+			}
+			if imageURL == "" {
+				continue
+			}
+			imgPath, _ := DownloadFile(imageURL, "./backend/images/"+model.Type, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
+			w, h, _ := GetImageDimensions(imgPath)
+			hash, _ := FileHash(imgPath)
+			metaBytes, _ := json.Marshal(img.Meta)
+			database.DB.Create(&models.VersionImage{
+				VersionID: version.ID,
+				Path:      imgPath,
+				Width:     w,
+				Height:    h,
+				Hash:      hash,
+				Meta:      string(metaBytes),
+			})
+			if idx == 0 {
+				imagePath = imgPath
+				imgW = w
+				imgH = h
+			}
+		}
+
+		version.ImagePath = imagePath
+		if model.ImagePath == version.ImagePath || model.ImagePath == "" {
+			model.ImagePath = imagePath
+			model.ImageWidth = imgW
+			model.ImageHeight = imgH
+		}
+	}
+
+	database.DB.Save(&model)
+	database.DB.Save(&version)
+
+	c.JSON(http.StatusOK, gin.H{"message": "Version refreshed"})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -37,6 +37,7 @@ func main() {
 		apiGroup.GET("/model/:id/versions", api.GetModelVersions)
 		apiGroup.GET("/versions/:id", api.GetVersion)
 		apiGroup.PUT("/versions/:id", api.UpdateVersion)
+		apiGroup.POST("/versions/:id/refresh", api.RefreshVersion)
 		apiGroup.DELETE("/versions/:id", api.DeleteVersion)
 	}
 

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -7,6 +7,18 @@
         Delete
       </button>
     </div>
+    <div class="mb-2 d-flex gap-2 pb-2" v-if="!isEditing">
+      <button @click="updateMeta" class="btn btn-secondary">
+        Update Metadata
+      </button>
+      <button @click="updateDesc" class="btn btn-secondary">
+        Update Description
+      </button>
+      <button @click="updateImages" class="btn btn-secondary">
+        Refresh Images
+      </button>
+      <button @click="updateAll" class="btn btn-secondary">Update All</button>
+    </div>
     <div v-else class="mb-2 d-flex gap-2 pb-2">
       <button @click="cancelEdit" class="btn btn-secondary">Cancel</button>
       <button @click="saveEdit" class="btn btn-primary">Save</button>
@@ -246,6 +258,31 @@ const saveEdit = async () => {
   isEditing.value = false;
   await fetchData();
   showToast("Saved", "success");
+};
+
+const refreshVersion = async (fields) => {
+  await axios.post(`/api/versions/${version.value.ID}/refresh`, null, {
+    params: { fields },
+  });
+  await fetchData();
+  showToast("Updated", "success");
+};
+
+const updateMeta = () => refreshVersion("metadata");
+const updateDesc = () => refreshVersion("description");
+const updateImages = async () => {
+  if (!(await showConfirm("Replace all images with the latest from CivitAI?")))
+    return;
+  await refreshVersion("images");
+};
+const updateAll = async () => {
+  if (
+    !(await showConfirm(
+      "Update all data from CivitAI? This will replace images.",
+    ))
+  )
+    return;
+  await refreshVersion("all");
 };
 
 const goBack = () => {


### PR DESCRIPTION
## Summary
- add backend route to refresh model version data from CivitAI
- wire POST `/versions/:id/refresh` in router
- expose buttons in model detail page to refresh metadata, description, images or all

## Testing
- `npm run lint`
- `npm run format`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687579c336d48332ac59b05ff4721c2d