### PR TITLE
Add creator username metadata

### DIFF
--- a/backend/api/types.go
+++ b/backend/api/types.go
@@ -1,13 +1,16 @@
 package api
 
 type CivitModel struct {
-	ID            int              `json:"id"`
-	Name          string           `json:"name"`
-	Type          string           `json:"type"`
-	Description   string           `json:"description"`
-	Nsfw          bool             `json:"nsfw"`
-	Tags          []string         `json:"tags"`
-	Mode          string           `json:"mode"`
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Nsfw        bool     `json:"nsfw"`
+	Tags        []string `json:"tags"`
+	Mode        string   `json:"mode"`
+	Creator     struct {
+		Username string `json:"username"`
+	} `json:"creator"`
 	ModelVersions []VersionSummary `json:"modelVersions"`
 	Created       string           `json:"createdAt"`
 	Updated       string           `json:"updatedAt"`

--- a/backend/models/model.go
+++ b/backend/models/model.go
@@ -4,12 +4,13 @@ import "gorm.io/gorm"
 
 type Model struct {
 	gorm.Model
-	CivitID     int    `gorm:"uniqueIndex" json:"civitId"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Tags        string `json:"tags"`
-	Nsfw        bool   `gorm:"column:nsfw" json:"nsfw"`
-	Description string `json:"description"`
+	CivitID         int    `gorm:"uniqueIndex" json:"civitId"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	CreatorUsername string `json:"creatorUsername"`
+	Tags            string `json:"tags"`
+	Nsfw            bool   `gorm:"column:nsfw" json:"nsfw"`
+	Description     string `json:"description"`
 
 	// Local paths
 	ImagePath string `json:"imagePath"`

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -63,6 +63,10 @@
                   }}</a>
                 </td>
               </tr>
+              <tr v-if="model.creatorUsername">
+                <th>Creator</th>
+                <td>{{ model.creatorUsername }}</td>
+              </tr>
               <tr v-if="version.createdAt">
                 <th>Created</th>
                 <td>{{ createdAtReadable }}</td>
@@ -240,6 +244,9 @@ const galleryImages = computed(() => {
     const meta = parseMeta(img.meta);
     if (version.value.mode) {
       meta.mode = version.value.mode;
+    }
+    if (model.value.creatorUsername) {
+      meta.creator = model.value.creatorUsername;
     }
     return {
       ...img,


### PR DESCRIPTION
## Summary
- support `creator.username` in backend API types
- store model creator username in database when fetching
- expose creator username in model detail view
- show creator name in gallery image metadata table

## Testing
- `go vet ./...`
- `go test ./...`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6875edc4d8948332a11724edfa54bbd1