### PR TITLE
Add JSON import endpoint

### DIFF
--- a/backend/api/import.go
+++ b/backend/api/import.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"model-manager/backend/database"
+	"model-manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+var modelIDRegex = regexp.MustCompile(`models/(\d+)`)
+var versionIDRegex = regexp.MustCompile(`modelVersionId=(\d+)`)
+
+// ImportModels handles JSON file uploads and inserts records into the database.
+func ImportModels(c *gin.Context) {
+	file, _, err := c.Request.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file required"})
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read file"})
+		return
+	}
+
+	var records []ImportRecord
+	if err := json.Unmarshal(data, &records); err != nil {
+		var rec ImportRecord
+		if err2 := json.Unmarshal(data, &rec); err2 == nil {
+			records = []ImportRecord{rec}
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+	}
+
+	for _, r := range records {
+		modelID := extractID(modelIDRegex, r.URL)
+		versionID := extractID(versionIDRegex, r.URL)
+		if modelID == 0 || versionID == 0 {
+			continue
+		}
+
+		modelName, verName := splitName(r.Name)
+		tags := strings.Join(r.Groups, ",")
+		nsfw := false
+		for _, g := range r.Groups {
+			if strings.EqualFold(g, "nsfw") {
+				nsfw = true
+				break
+			}
+		}
+
+		var model models.Model
+		database.DB.Where("civit_id = ?", modelID).First(&model)
+		if model.ID == 0 {
+			model = models.Model{
+				CivitID:     modelID,
+				Name:        modelName,
+				Type:        r.ModelType,
+				Tags:        tags,
+				Nsfw:        nsfw,
+				Description: r.Description,
+			}
+			database.DB.Create(&model)
+		}
+
+		var ver models.Version
+		database.DB.Unscoped().Where("version_id = ?", versionID).First(&ver)
+		if ver.ID != 0 {
+			continue
+		}
+
+		createdStr := ""
+		if r.CreatedAt > 0 {
+			t := time.Unix(int64(r.CreatedAt), 0)
+			createdStr = t.Format(time.RFC3339)
+		}
+
+		ver = models.Version{
+			ModelID:        model.ID,
+			VersionID:      versionID,
+			Name:           verName,
+			BaseModel:      r.BaseModel,
+			TrainedWords:   r.PositivePrompts,
+			Nsfw:           nsfw,
+			Type:           r.ModelType,
+			Tags:           tags,
+			Description:    r.Description,
+			ModelURL:       r.URL,
+			SHA256:         r.SHA256Hash,
+			DownloadURL:    r.DownloadURL,
+			FilePath:       r.Location,
+			CivitCreatedAt: createdStr,
+		}
+		database.DB.Create(&ver)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "import complete"})
+}
+
+func extractID(re *regexp.Regexp, url string) int {
+	m := re.FindStringSubmatch(url)
+	if len(m) > 1 {
+		id, _ := strconv.Atoi(m[1])
+		return id
+	}
+	return 0
+}
+
+func splitName(name string) (string, string) {
+	if strings.HasSuffix(name, ")") {
+		if i := strings.LastIndex(name, "("); i != -1 {
+			model := strings.TrimSpace(name[:i])
+			ver := strings.TrimRight(strings.TrimSpace(name[i+1:]), ")")
+			return model, ver
+		}
+	}
+	return name, name
+}

--- a/backend/api/types.go
+++ b/backend/api/types.go
@@ -62,3 +62,20 @@ type VersionInfo struct {
 	Created              string   `json:"createdAt"`
 	Updated              string   `json:"updatedAt"`
 }
+
+// ImportRecord represents a single entry in the JSON import file.
+// Only a subset of fields are mapped into the database.
+type ImportRecord struct {
+	Name            string   `json:"name"`
+	BaseModel       string   `json:"base_model"`
+	ModelType       string   `json:"model_type"`
+	DownloadURL     string   `json:"download_url"`
+	URL             string   `json:"url"`
+	PreviewURL      string   `json:"preview_url"`
+	Description     string   `json:"description"`
+	PositivePrompts string   `json:"positive_prompts"`
+	SHA256Hash      string   `json:"sha256_hash"`
+	CreatedAt       float64  `json:"created_at"`
+	Groups          []string `json:"groups"`
+	Location        string   `json:"location"`
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -40,6 +40,7 @@ func main() {
 		apiGroup.POST("/versions/:id/refresh", api.RefreshVersion)
 		apiGroup.POST("/versions/:id/main-image/:imageId", api.SetVersionMainImage)
 		apiGroup.DELETE("/versions/:id", api.DeleteVersion)
+		apiGroup.POST("/import", api.ImportModels)
 	}
 
 	// Vue SPA fallback for all other routes (no wildcard)

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -119,6 +119,24 @@
             {{ downloadProgress }}%
           </div>
         </div>
+
+        <div class="input-group mt-2">
+          <input
+            type="file"
+            accept=".json"
+            @change="onFileChange"
+            class="form-control"
+          />
+          <div class="input-group-append">
+            <button
+              @click="importJson"
+              :disabled="!importFile"
+              class="btn btn-primary"
+            >
+              Import
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -189,6 +207,7 @@ const selectedVersionId = ref("");
 const loading = ref(false);
 const downloading = ref(false);
 const downloadProgress = ref(0);
+const importFile = ref(null);
 let progressInterval = null;
 const router = useRouter();
 
@@ -397,5 +416,26 @@ const goToModel = (modelId, versionId) => {
 const loadMore = async () => {
   page.value += 1;
   await fetchModels();
+};
+
+const onFileChange = (e) => {
+  importFile.value = e.target.files[0] || null;
+};
+
+const importJson = async () => {
+  if (!importFile.value) return;
+  const form = new FormData();
+  form.append("file", importFile.value);
+  try {
+    await axios.post("/api/import", form);
+    page.value = 1;
+    await fetchModels(true);
+    showToast("Import successful", "success");
+  } catch (err) {
+    console.error(err);
+    showToast("Import failed", "danger");
+  } finally {
+    importFile.value = null;
+  }
 };
 </script>


### PR DESCRIPTION
## Summary
- add ImportRecord struct for JSON fields
- implement ImportModels handler to parse uploaded JSON and insert models & versions
- expose import route in backend
- add import controls in UI for uploading a JSON file

## Testing
- `go vet ./...`
- `go build ./...`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875f535a13c8332acfcdb161130d004