### PR TITLE
Fix settings navigation and reduce log noise

### DIFF
--- a/backend/database/settings.go
+++ b/backend/database/settings.go
@@ -5,7 +5,8 @@ import "model-manager/backend/models"
 // GetSettingValue returns the value for the given key or empty string if not found.
 func GetSettingValue(key string) string {
 	var s models.Setting
-	if err := DB.First(&s, "key = ?", key).Error; err == nil {
+	result := DB.Where("key = ?", key).Limit(1).Find(&s)
+	if result.Error == nil && result.RowsAffected > 0 {
 		return s.Value
 	}
 	return ""

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,7 +32,11 @@
           stroke-linejoin="round"
         ></path>
       </svg>
-      <h1 class="h5 text-primary-emphasis my-auto fw-bold">Model Manager</h1>
+      <router-link
+        to="/"
+        class="h5 text-primary-emphasis my-auto fw-bold text-decoration-none"
+        >Model Manager</router-link
+      >
     </div>
     <router-view />
     <div

--- a/frontend/src/components/AppSettings.vue
+++ b/frontend/src/components/AppSettings.vue
@@ -16,10 +16,12 @@
 
 <script setup>
 import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
 import axios from "axios";
 import { showToast } from "../utils/ui";
 
 const apiKey = ref("");
+const router = useRouter();
 
 onMounted(async () => {
   const res = await axios.get("/api/settings");
@@ -33,5 +35,9 @@ async function save() {
     value: apiKey.value,
   });
   showToast("Settings saved");
+}
+
+function goBack() {
+  router.push("/");
 }
 </script>


### PR DESCRIPTION
## Summary
- link the header title to the model list
- wire up the back button on the settings page
- avoid `record not found` logging for missing settings

## Testing
- `npm run lint`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687720a551a88332ad4228d22fca585f