### PR TITLE
Auto-select singular model version

### DIFF
--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -368,7 +368,7 @@ const loadVersions = async () => {
     const vid = extractVersionId(modelUrl.value);
     if (vid && res.data.some((v) => v.id === Number(vid))) {
       selectedVersionId.value = vid;
-    } else if (res.data.length) {
+    } else if (res.data.length === 1) {
       selectedVersionId.value = String(res.data[0].id);
     } else {
       selectedVersionId.value = "";


### PR DESCRIPTION
## Summary
- tweak the importer UI to choose a version automatically only if the model has a single version

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879d54c60a48332afc4aea2ea4c5798