### PR TITLE
Add orphan file tool

### DIFF
--- a/backend/api/orphan.go
+++ b/backend/api/orphan.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"model-manager/backend/database"
+	"model-manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetOrphanFiles scans the downloads folder for .safetensors or .pt files
+// that are not referenced by any model or version record. It returns a list
+// of file names that have no associated record.
+func GetOrphanFiles(c *gin.Context) {
+	var orphans []string
+	root := "./backend/downloads"
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(info.Name()))
+		if ext != ".safetensors" && ext != ".pt" {
+			return nil
+		}
+		abs, _ := filepath.Abs(path)
+		var count int64
+		database.DB.Model(&models.Version{}).Where("file_path = ?", abs).Or("file_path = ?", path).Count(&count)
+		if count == 0 {
+			database.DB.Model(&models.Model{}).Where("file_path = ?", abs).Or("file_path = ?", path).Count(&count)
+		}
+		if count == 0 {
+			orphans = append(orphans, info.Name())
+		}
+		return nil
+	})
+
+	c.JSON(http.StatusOK, gin.H{"files": orphans})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -45,6 +45,7 @@ func main() {
 		apiGroup.GET("/export", api.ExportModels)
 		apiGroup.GET("/settings", api.GetSettings)
 		apiGroup.POST("/settings", api.UpdateSetting)
+		apiGroup.GET("/orphan-files", api.GetOrphanFiles)
 	}
 
 	// Vue SPA fallback for all other routes (no wildcard)


### PR DESCRIPTION
## Summary
- show untracked downloads on data page
- add API endpoint to scan downloads directory for unassociated `.safetensors` and `.pt` files

## Testing
- `go vet ./...`
- `go build ./...`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bd84880ec8332ac1dc0a75e02a9e7