### PR TITLE
Enable manual model creation

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -30,6 +30,7 @@ func main() {
 		apiGroup.GET("/models/count", api.GetModelsCount)
 		apiGroup.GET("/base-models", api.GetBaseModels)
 		apiGroup.GET("/models/:id", api.GetModel)
+		apiGroup.POST("/models", api.CreateModel)
 		apiGroup.PUT("/models/:id", api.UpdateModel)
 		apiGroup.DELETE("/models/:id", api.DeleteModel)
 		apiGroup.POST("/sync", api.SyncCivitModels)

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -350,7 +350,12 @@ const fetchData = async () => {
   version.value = res.data.version;
 };
 
-onMounted(fetchData);
+onMounted(async () => {
+  await fetchData();
+  if (route.query.edit === "1") {
+    startEdit();
+  }
+});
 
 watch(isEditing, async (val) => {
   if (val) {

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -133,6 +133,12 @@
     </div>
   </div>
 
+  <div class="text-end my-3">
+    <button @click="createManualModel" class="btn btn-primary">
+      Add Model
+    </button>
+  </div>
+
   <nav v-if="totalPages > 1" class="mb-4">
     <ul class="pagination justify-content-center align-items-center gap-1">
       <li class="page-item" :class="{ disabled: page === 1 }">
@@ -456,7 +462,8 @@ const versionCards = computed(() => {
           const tags = (v.tags || "")
             .split(",")
             .map((t) => t.trim().toLowerCase());
-          if (!tags.includes(selectedCategory.value.toLowerCase())) return false;
+          if (!tags.includes(selectedCategory.value.toLowerCase()))
+            return false;
         }
 
         if (tagsSearch.value.trim()) {
@@ -589,5 +596,16 @@ const changePage = async (p) => {
 
 const goToPage = async () => {
   await changePage(pageInput.value);
+};
+
+const createManualModel = async () => {
+  try {
+    const res = await axios.post("/api/models");
+    const { modelId, versionId } = res.data;
+    router.push(`/model/${modelId}/version/${versionId}?edit=1`);
+  } catch (err) {
+    console.error(err);
+    showToast("Failed to create model", "danger");
+  }
 };
 </script>


### PR DESCRIPTION
## Summary
- allow creating manual models with backend POST /models
- navigate to edit mode for the new model
- support edit query param on model details page
- provide Add Model button on list page

## Testing
- `gofmt -w backend/api/handlers.go backend/main.go`
- `npx prettier -w frontend/src/components/ModelDetail.vue frontend/src/components/ModelList.vue`

------
https://chatgpt.com/codex/tasks/task_e_688af1640e9c83328a475cbfb8b61a7a