### PR TITLE
Add delete version options

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -38,11 +38,55 @@
         >Model Manager</router-link
       >
       <router-link to="/utilities" class="btn btn-outline-secondary btn-sm"
-        ><svg width="22px" height="22px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#ffffff"><path d="M10.0503 10.6066L2.97923 17.6777C2.19818 18.4587 2.19818 19.725 2.97923 20.5061V20.5061C3.76027 21.2871 5.0266 21.2871 5.80765 20.5061L12.8787 13.435" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10.0502 10.6066C9.20638 8.45358 9.37134 5.6286 11.1109 3.88909C12.8504 2.14957 16.0606 1.76777 17.8284 2.82843L14.7877 5.8691L14.5051 8.98014L17.6161 8.69753L20.6568 5.65685C21.7175 7.42462 21.3357 10.6349 19.5961 12.3744C17.8566 14.1139 15.0316 14.2789 12.8786 13.435" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></router-link
-      >
+        ><svg
+          width="22px"
+          height="22px"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          color="#ffffff"
+        >
+          <path
+            d="M10.0503 10.6066L2.97923 17.6777C2.19818 18.4587 2.19818 19.725 2.97923 20.5061V20.5061C3.76027 21.2871 5.0266 21.2871 5.80765 20.5061L12.8787 13.435"
+            stroke="#ffffff"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M10.0502 10.6066C9.20638 8.45358 9.37134 5.6286 11.1109 3.88909C12.8504 2.14957 16.0606 1.76777 17.8284 2.82843L14.7877 5.8691L14.5051 8.98014L17.6161 8.69753L20.6568 5.65685C21.7175 7.42462 21.3357 10.6349 19.5961 12.3744C17.8566 14.1139 15.0316 14.2789 12.8786 13.435"
+            stroke="#ffffff"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path></svg
+      ></router-link>
       <router-link to="/settings" class="btn btn-outline-secondary btn-sm"
-        ><svg width="22px" height="22px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#ffffff"><path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19.6224 10.3954L18.5247 7.7448L20 6L18 4L16.2647 5.48295L13.5578 4.36974L12.9353 2H10.981L10.3491 4.40113L7.70441 5.51596L6 4L4 6L5.45337 7.78885L4.3725 10.4463L2 11V13L4.40111 13.6555L5.51575 16.2997L4 18L6 20L7.79116 18.5403L10.397 19.6123L11 22H13L13.6045 19.6132L16.2551 18.5155C16.6969 18.8313 18 20 18 20L20 18L18.5159 16.2494L19.6139 13.598L21.9999 12.9772L22 11L19.6224 10.3954Z" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg></router-link
-      >
+        ><svg
+          width="22px"
+          height="22px"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          color="#ffffff"
+        >
+          <path
+            d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z"
+            stroke="#ffffff"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path>
+          <path
+            d="M19.6224 10.3954L18.5247 7.7448L20 6L18 4L16.2647 5.48295L13.5578 4.36974L12.9353 2H10.981L10.3491 4.40113L7.70441 5.51596L6 4L4 6L5.45337 7.78885L4.3725 10.4463L2 11V13L4.40111 13.6555L5.51575 16.2997L4 18L6 20L7.79116 18.5403L10.397 19.6123L11 22H13L13.6045 19.6132L16.2551 18.5155C16.6969 18.8313 18 20 18 20L20 18L18.5159 16.2494L19.6139 13.598L21.9999 12.9772L22 11L19.6224 10.3954Z"
+            stroke="#ffffff"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ></path></svg
+      ></router-link>
     </div>
     <router-view />
     <div
@@ -61,7 +105,23 @@
             >
               Cancel
             </button>
-            <button type="button" class="btn btn-primary">OK</button>
+            <button id="confirm-ok" type="button" class="btn btn-primary">
+              OK
+            </button>
+            <button
+              id="confirm-delete"
+              type="button"
+              class="btn btn-primary d-none"
+            >
+              Delete Version
+            </button>
+            <button
+              id="confirm-delete-files"
+              type="button"
+              class="btn btn-danger d-none"
+            >
+              Delete Version &amp; Files
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -14,11 +14,7 @@
     <div v-if="!isEditing">
       <div class="row">
         <div class="col-md-4">
-          <img
-            v-if="imageUrl"
-            :src="imageUrl"
-            class="img-fluid mb-4"
-          />
+          <img v-if="imageUrl" :src="imageUrl" class="img-fluid mb-4" />
         </div>
         <div class="col-md-8">
           <h2 class="fw-bold">{{ model.name }}</h2>
@@ -86,7 +82,7 @@
                 </tr>
               </tbody>
             </table>
-          </div>    
+          </div>
         </div>
       </div>
       <div
@@ -278,7 +274,7 @@ import { ref, onMounted, computed, nextTick, watch } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import axios from "axios";
 import Quill from "quill";
-import { showToast, showConfirm } from "../utils/ui";
+import { showToast, showConfirm, showDeleteConfirm } from "../utils/ui";
 
 const router = useRouter();
 const route = useRoute();
@@ -378,8 +374,10 @@ watch(isEditing, async (val) => {
 });
 
 const deleteVersion = async () => {
-  if (!(await showConfirm("Delete this version and all files?"))) return;
-  await axios.delete(`/api/versions/${route.params.versionId}`);
+  const choice = await showDeleteConfirm("Delete this version?");
+  if (!choice) return;
+  const files = choice === "deleteFiles" ? 1 : 0;
+  await axios.delete(`/api/versions/${route.params.versionId}?files=${files}`);
   router.push("/");
 };
 

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -9,9 +9,7 @@
           style="min-width: 200px"
         />
       </div>
-      <div
-        class="col"
-      >
+      <div class="col">
         <input
           v-model="tagsSearch"
           placeholder="Search tags (comma separated)"
@@ -83,7 +81,10 @@
     <div v-show="showAddPanel" class="card card-body my-3">
       <div class="row g-3">
         <div class="col-md-2">
-          <button @click="createManualModel" class="btn btn-outline-primary w-100">
+          <button
+            @click="createManualModel"
+            class="btn btn-outline-primary w-100"
+          >
             Add Model
           </button>
         </div>
@@ -273,7 +274,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { useRouter } from "vue-router";
 import axios from "axios";
-import { showToast, showConfirm } from "../utils/ui";
+import { showToast, showDeleteConfirm } from "../utils/ui";
 import debounce from "../utils/debounce";
 
 const models = ref([]);
@@ -603,8 +604,10 @@ const downloadSelectedVersion = async () => {
 };
 
 const deleteVersion = async (id) => {
-  if (!(await showConfirm("Delete this version and all files?"))) return;
-  await axios.delete(`/api/versions/${id}`);
+  const choice = await showDeleteConfirm("Delete this version?");
+  if (!choice) return;
+  const files = choice === "deleteFiles" ? 1 : 0;
+  await axios.delete(`/api/versions/${id}?files=${files}`);
   page.value = 1;
   await fetchTotal();
   await fetchModels();

--- a/frontend/src/utils/ui.js
+++ b/frontend/src/utils/ui.js
@@ -17,8 +17,13 @@ export function showConfirm(message) {
   return new Promise((resolve) => {
     const el = document.getElementById("confirm-modal");
     el.querySelector(".modal-body").textContent = message;
-    const okBtn = el.querySelector(".btn-primary");
+    const okBtn = el.querySelector("#confirm-ok");
     const cancelBtn = el.querySelector(".btn-secondary");
+    const delBtn = el.querySelector("#confirm-delete");
+    const delFilesBtn = el.querySelector("#confirm-delete-files");
+    delBtn.classList.add("d-none");
+    delFilesBtn.classList.add("d-none");
+    okBtn.classList.remove("d-none");
     const modal = new Modal(el);
     const cleanup = (result) => {
       okBtn.removeEventListener("click", ok);
@@ -34,6 +39,43 @@ export function showConfirm(message) {
       cleanup(false);
     };
     okBtn.addEventListener("click", ok);
+    cancelBtn.addEventListener("click", cancel);
+    modal.show();
+  });
+}
+
+export function showDeleteConfirm(message) {
+  return new Promise((resolve) => {
+    const el = document.getElementById("confirm-modal");
+    el.querySelector(".modal-body").textContent = message;
+    const okBtn = el.querySelector("#confirm-ok");
+    const delBtn = el.querySelector("#confirm-delete");
+    const delFilesBtn = el.querySelector("#confirm-delete-files");
+    const cancelBtn = el.querySelector(".btn-secondary");
+    okBtn.classList.add("d-none");
+    delBtn.classList.remove("d-none");
+    delFilesBtn.classList.remove("d-none");
+    const modal = new Modal(el);
+    const cleanup = (result) => {
+      delBtn.removeEventListener("click", doDelete);
+      delFilesBtn.removeEventListener("click", doDeleteFiles);
+      cancelBtn.removeEventListener("click", cancel);
+      resolve(result);
+    };
+    const doDelete = () => {
+      modal.hide();
+      cleanup("delete");
+    };
+    const doDeleteFiles = () => {
+      modal.hide();
+      cleanup("deleteFiles");
+    };
+    const cancel = () => {
+      modal.hide();
+      cleanup(null);
+    };
+    delBtn.addEventListener("click", doDelete);
+    delFilesBtn.addEventListener("click", doDeleteFiles);
     cancelBtn.addEventListener("click", cancel);
     modal.show();
   });


### PR DESCRIPTION
## Summary
- enhance confirmation modal with extra buttons
- support multiple confirmation options in UI utilities
- add delete confirmation options when removing a version
- allow database-only deletion of a version via API

## Testing
- `npm run lint`
- `npm run format`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b1df1ae508332b244bde9a43b525f