### PR TITLE
Implement scroll helpers

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -89,6 +89,7 @@
       ></router-link>
     </div>
     <router-view />
+    <BackToTop />
     <div
       id="toast-container"
       class="toast-container position-fixed bottom-0 end-0 p-3"
@@ -129,4 +130,6 @@
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import BackToTop from "./components/BackToTop.vue";
+</script>

--- a/frontend/src/components/BackToTop.vue
+++ b/frontend/src/components/BackToTop.vue
@@ -1,0 +1,40 @@
+<template>
+  <button
+    class="btn btn-primary back-to-top"
+    v-show="visible"
+    @click="scrollToTop"
+  >
+    ↑ Top
+  </button>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from "vue";
+
+const visible = ref(false);
+
+const handleScroll = () => {
+  visible.value = window.scrollY > 200;
+};
+
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
+
+onMounted(() => {
+  window.addEventListener("scroll", handleScroll);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("scroll", handleScroll);
+});
+</script>
+
+<style scoped>
+.back-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1050;
+}
+</style>

--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -110,7 +110,10 @@
               >
                 Set as Main
               </button>
-              <span v-else class="badge text-bg-success d-block text-center mt-1 py-2">
+              <span
+                v-else
+                class="badge text-bg-success d-block text-center mt-1 py-2"
+              >
                 Main Image
               </span>
             </div>
@@ -460,7 +463,7 @@ const updateAll = async () => {
 };
 
 const goBack = () => {
-  router.push("/");
+  router.push({ path: "/", query: { scrollTo: version.value.ID } });
 };
 
 const setMainImage = async (img) => {

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -197,6 +197,7 @@
     <div
       v-for="card in versionCards"
       :key="card.version.ID"
+      :id="`model-${card.version.ID}`"
       class="model-card card h-100"
     >
       <img
@@ -271,8 +272,8 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from "vue";
-import { useRouter } from "vue-router";
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
+import { useRouter, useRoute } from "vue-router";
 import axios from "axios";
 import { showToast, showDeleteConfirm } from "../utils/ui";
 import debounce from "../utils/debounce";
@@ -293,6 +294,7 @@ const downloading = ref(false);
 const downloadProgress = ref(0);
 let progressInterval = null;
 const router = useRouter();
+const route = useRoute();
 
 const page = ref(1);
 const pageInput = ref(1);
@@ -370,6 +372,16 @@ onMounted(async () => {
   await fetchTotal();
   await fetchModels();
   initialized.value = true;
+  if (route.query.scrollTo) {
+    await nextTick();
+    const el = document.getElementById(`model-${route.query.scrollTo}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+    }
+    const rest = { ...route.query };
+    delete rest.scrollTo;
+    router.replace({ path: route.path, query: rest });
+  }
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- create a BackToTop component and render it from `App.vue`
- add scroll-to-element query logic in the model list
- jump back to selected model after returning from model detail

## Testing
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c35d8f7a88332b9d63a7508f5f8d8