### PR TITLE
Add Stats section with charts

### DIFF
--- a/backend/api/stats.go
+++ b/backend/api/stats.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"net/http"
+
+	"model-manager/backend/database"
+	"model-manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+type countResult struct {
+	Key   string
+	Count int64
+}
+
+// GetStats returns summary statistics about the models in the database.
+func GetStats(c *gin.Context) {
+	var total int64
+	database.DB.Model(&models.Model{}).Count(&total)
+
+	var typeResults []countResult
+	database.DB.Model(&models.Model{}).
+		Select("type as key, count(*) as count").
+		Group("type").Scan(&typeResults)
+
+	var baseResults []countResult
+	database.DB.Model(&models.Version{}).
+		Select("base_model as key, count(*) as count").
+		Group("base_model").Scan(&baseResults)
+
+	var nsfwRows []struct {
+		Nsfw  bool
+		Count int64
+	}
+	database.DB.Model(&models.Model{}).
+		Select("nsfw, count(*) as count").
+		Group("nsfw").Scan(&nsfwRows)
+
+	nsfwCount := int64(0)
+	safeCount := int64(0)
+	for _, r := range nsfwRows {
+		if r.Nsfw {
+			nsfwCount += r.Count
+		} else {
+			safeCount += r.Count
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"totalModels":     total,
+		"typeCounts":      typeResults,
+		"baseModelCounts": baseResults,
+		"nsfwCount":       nsfwCount,
+		"nonNsfwCount":    safeCount,
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -49,6 +49,7 @@ func main() {
 		apiGroup.POST("/import", api.ImportModels)
 		apiGroup.POST("/import-db", api.ImportDatabase)
 		apiGroup.GET("/export", api.ExportModels)
+		apiGroup.GET("/stats", api.GetStats)
 		apiGroup.GET("/settings", api.GetSettings)
 		apiGroup.POST("/settings", api.UpdateSetting)
 	}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/frontend/src/components/UtilitiesPage.vue
+++ b/frontend/src/components/UtilitiesPage.vue
@@ -4,42 +4,90 @@
       <button @click="goBack" class="btn btn-secondary">Back</button>
     </div>
     <h2 class="my-3">Utilities</h2>
+    <div class="card card-body mb-4" v-if="stats">
+      <h3 class="h5">Stats</h3>
+      <p>Total Models: {{ stats.totalModels }}</p>
+      <ul class="mb-3">
+        <li v-for="t in stats.typeCounts" :key="t.Key">
+          {{ t.Key || "Unknown" }}: {{ t.Count }}
+        </li>
+      </ul>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <canvas id="baseModelChart"></canvas>
+        </div>
+        <div class="col-md-6 mb-3">
+          <canvas id="nsfwChart"></canvas>
+        </div>
+      </div>
+    </div>
     <h3 class="h5 mt-5">Import JSON from Model Organizer</h3>
     <div class="input-group mb-3">
-      <input type="file" accept=".json" @change="onFileChange" class="form-control" />
+      <input
+        type="file"
+        accept=".json"
+        @change="onFileChange"
+        class="form-control"
+      />
       <div class="input-group-append">
-        <button @click="importJson" :disabled="!importFile" class="btn btn-primary">
-        Import
+        <button
+          @click="importJson"
+          :disabled="!importFile"
+          class="btn btn-primary"
+        >
+          Import
         </button>
       </div>
     </div>
     <div class="d-flex gap-2 mb-3">
       <span>Update:</span>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="ie-pull-images" v-model="pullImages" />
+        <input
+          class="form-check-input"
+          type="checkbox"
+          id="ie-pull-images"
+          v-model="pullImages"
+        />
         <label class="form-check-label" for="ie-pull-images">Images</label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="ie-pull-meta" v-model="pullMeta" />
+        <input
+          class="form-check-input"
+          type="checkbox"
+          id="ie-pull-meta"
+          v-model="pullMeta"
+        />
         <label class="form-check-label" for="ie-pull-meta">Metadata</label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="ie-pull-desc" v-model="pullDesc" />
+        <input
+          class="form-check-input"
+          type="checkbox"
+          id="ie-pull-desc"
+          v-model="pullDesc"
+        />
         <label class="form-check-label" for="ie-pull-desc">Description</label>
       </div>
     </div>
     <h3 class="h5 mt-5">Export Database as JSON</h3>
     <div class="mb-3 d-flex gap-2">
-      <button @click="exportJson" class="btn btn-primary">
-        Export Models
-      </button>
+      <button @click="exportJson" class="btn btn-primary">Export Models</button>
     </div>
     <h3 class="h5 mt-5">Import Database JSON</h3>
     <div class="input-group mb-3">
-      <input type="file" accept=".json" @change="onDbFileChange" class="form-control" />
+      <input
+        type="file"
+        accept=".json"
+        @change="onDbFileChange"
+        class="form-control"
+      />
       <div class="input-group-append">
-        <button @click="importDbJson" :disabled="!dbImportFile" class="btn btn-primary">
-        Import
+        <button
+          @click="importDbJson"
+          :disabled="!dbImportFile"
+          class="btn btn-primary"
+        >
+          Import
         </button>
       </div>
     </div>
@@ -47,78 +95,131 @@
 </template>
 
 <script setup>
- 
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
-import axios from 'axios'
-import { showToast } from '../utils/ui'
+/* global Chart */
+import { ref, onMounted, nextTick } from "vue";
+import { useRouter } from "vue-router";
+import axios from "axios";
+import { showToast } from "../utils/ui";
 
-const importFile = ref(null)
-const dbImportFile = ref(null)
-const pullImages = ref(false)
-const pullMeta = ref(false)
-const pullDesc = ref(false)
-const router = useRouter()
+const stats = ref(null);
+let baseChart = null;
+let nsfwChart = null;
+
+onMounted(async () => {
+  try {
+    const res = await axios.get("/api/stats");
+    stats.value = res.data;
+    await nextTick();
+    renderCharts();
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+function renderCharts() {
+  if (!stats.value) return;
+  if (baseChart) baseChart.destroy();
+  if (nsfwChart) nsfwChart.destroy();
+
+  const baseCtx = document.getElementById("baseModelChart");
+  if (baseCtx) {
+    baseChart = new Chart(baseCtx, {
+      type: "pie",
+      data: {
+        labels: stats.value.baseModelCounts.map((b) => b.Key || "Unknown"),
+        datasets: [
+          {
+            data: stats.value.baseModelCounts.map((b) => b.Count),
+          },
+        ],
+      },
+    });
+  }
+
+  const nsfwCtx = document.getElementById("nsfwChart");
+  if (nsfwCtx) {
+    nsfwChart = new Chart(nsfwCtx, {
+      type: "pie",
+      data: {
+        labels: ["Non-NSFW", "NSFW"],
+        datasets: [
+          {
+            data: [stats.value.nonNsfwCount, stats.value.nsfwCount],
+          },
+        ],
+      },
+    });
+  }
+}
+
+const importFile = ref(null);
+const dbImportFile = ref(null);
+const pullImages = ref(false);
+const pullMeta = ref(false);
+const pullDesc = ref(false);
+const router = useRouter();
 
 const onFileChange = (e) => {
-  importFile.value = e.target.files[0] || null
-}
+  importFile.value = e.target.files[0] || null;
+};
 
 const onDbFileChange = (e) => {
-  dbImportFile.value = e.target.files[0] || null
-}
+  dbImportFile.value = e.target.files[0] || null;
+};
 
 const importJson = async () => {
-  if (!importFile.value) return
-  const form = new FormData()
-  form.append('file', importFile.value)
+  if (!importFile.value) return;
+  const form = new FormData();
+  form.append("file", importFile.value);
   try {
-    const params = []
-    if (pullMeta.value) params.push('metadata')
-    if (pullDesc.value) params.push('description')
-    if (pullImages.value) params.push('images')
-    const query = params.length ? `?fields=${params.join(',')}` : ''
-    await axios.post(`/api/import${query}`, form)
-    showToast('Import successful', 'success')
+    const params = [];
+    if (pullMeta.value) params.push("metadata");
+    if (pullDesc.value) params.push("description");
+    if (pullImages.value) params.push("images");
+    const query = params.length ? `?fields=${params.join(",")}` : "";
+    await axios.post(`/api/import${query}`, form);
+    showToast("Import successful", "success");
   } catch (err) {
-    console.error(err)
-    showToast('Import failed', 'danger')
+    console.error(err);
+    showToast("Import failed", "danger");
   } finally {
-    importFile.value = null
+    importFile.value = null;
   }
-}
+};
 
 const importDbJson = async () => {
-  if (!dbImportFile.value) return
-  const form = new FormData()
-  form.append('file', dbImportFile.value)
+  if (!dbImportFile.value) return;
+  const form = new FormData();
+  form.append("file", dbImportFile.value);
   try {
-    await axios.post('/api/import-db', form)
-    showToast('Database import successful', 'success')
+    await axios.post("/api/import-db", form);
+    showToast("Database import successful", "success");
   } catch (err) {
-    console.error(err)
-    showToast('Database import failed', 'danger')
+    console.error(err);
+    showToast("Database import failed", "danger");
   } finally {
-    dbImportFile.value = null
+    dbImportFile.value = null;
   }
-}
+};
 
 const exportJson = async () => {
   try {
-    const res = await axios.get('/api/export', { responseType: 'blob' })
-    const url = window.URL.createObjectURL(new Blob([res.data], { type: 'application/json' }))
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'model_export.json'
-    a.click()
-    window.URL.revokeObjectURL(url)
+    const res = await axios.get("/api/export", { responseType: "blob" });
+    const url = window.URL.createObjectURL(
+      new Blob([res.data], { type: "application/json" }),
+    );
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "model_export.json";
+    a.click();
+    window.URL.revokeObjectURL(url);
   } catch (err) {
-    console.error(err)
-    showToast('Export failed', 'danger')
+    console.error(err);
+    showToast("Export failed", "danger");
   }
-}
+};
 
 const goBack = () => {
-  router.push('/')
-}
+  router.push("/");
+};
 </script>

--- a/frontend/src/components/UtilitiesPage.vue
+++ b/frontend/src/components/UtilitiesPage.vue
@@ -5,7 +5,8 @@
     </div>
     <h2 class="my-3">Utilities</h2>
     <div class="card card-body mb-4" v-if="stats">
-      <h3 class="h5">Stats</h3>
+      <h3>Stats</h3>
+      <p class="text-center h5 mb-3">Total Models: <strong>{{ stats.totalModels }}</strong></p>
       <div class="row text-center">
         <div class="col-md-4 mb-3">
           <canvas id="typeChart"></canvas>
@@ -17,76 +18,78 @@
           <canvas id="nsfwChart"></canvas>
         </div>
       </div>
-      <p class="text-center">Total Models: {{ stats.totalModels }}</p>
     </div>
-    <h3 class="h5 mt-5">Import JSON from Model Organizer</h3>
-    <div class="input-group mb-3">
-      <input
-        type="file"
-        accept=".json"
-        @change="onFileChange"
-        class="form-control"
-      />
-      <div class="input-group-append">
-        <button
-          @click="importJson"
-          :disabled="!importFile"
-          class="btn btn-primary"
-        >
-          Import
-        </button>
-      </div>
-    </div>
-    <div class="d-flex gap-2 mb-3">
-      <span>Update:</span>
-      <div class="form-check">
+    <div class="card card-body">
+      <h3>Import & Export</h3>
+      <h4 class="h5 my-3">Import JSON from Model Organizer</h4>
+      <div class="input-group mb-3">
         <input
-          class="form-check-input"
-          type="checkbox"
-          id="ie-pull-images"
-          v-model="pullImages"
+          type="file"
+          accept=".json"
+          @change="onFileChange"
+          class="form-control"
         />
-        <label class="form-check-label" for="ie-pull-images">Images</label>
+        <div class="input-group-append">
+          <button
+            @click="importJson"
+            :disabled="!importFile"
+            class="btn btn-primary"
+          >
+            Import
+          </button>
+        </div>
       </div>
-      <div class="form-check">
+      <div class="d-flex gap-2 mb-3">
+        <span>Update:</span>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="ie-pull-images"
+            v-model="pullImages"
+          />
+          <label class="form-check-label" for="ie-pull-images">Images</label>
+        </div>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="ie-pull-meta"
+            v-model="pullMeta"
+          />
+          <label class="form-check-label" for="ie-pull-meta">Metadata</label>
+        </div>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="ie-pull-desc"
+            v-model="pullDesc"
+          />
+          <label class="form-check-label" for="ie-pull-desc">Description</label>
+        </div>
+      </div>
+      <h4 class="h5 my-3">Export Database as JSON</h4>
+      <div class="mb-3 d-flex gap-2">
+        <button @click="exportJson" class="btn btn-primary">Export Models</button>
+      </div>
+      <h4 class="h5 my-3">Import Database from JSON</h4>
+      <div class="input-group mb-3">
         <input
-          class="form-check-input"
-          type="checkbox"
-          id="ie-pull-meta"
-          v-model="pullMeta"
+          type="file"
+          accept=".json"
+          @change="onDbFileChange"
+          class="form-control"
         />
-        <label class="form-check-label" for="ie-pull-meta">Metadata</label>
-      </div>
-      <div class="form-check">
-        <input
-          class="form-check-input"
-          type="checkbox"
-          id="ie-pull-desc"
-          v-model="pullDesc"
-        />
-        <label class="form-check-label" for="ie-pull-desc">Description</label>
-      </div>
-    </div>
-    <h3 class="h5 mt-5">Export Database as JSON</h3>
-    <div class="mb-3 d-flex gap-2">
-      <button @click="exportJson" class="btn btn-primary">Export Models</button>
-    </div>
-    <h3 class="h5 mt-5">Import Database JSON</h3>
-    <div class="input-group mb-3">
-      <input
-        type="file"
-        accept=".json"
-        @change="onDbFileChange"
-        class="form-control"
-      />
-      <div class="input-group-append">
-        <button
-          @click="importDbJson"
-          :disabled="!dbImportFile"
-          class="btn btn-primary"
-        >
-          Import
-        </button>
+        <div class="input-group-append">
+          <button
+            @click="importDbJson"
+            :disabled="!dbImportFile"
+            class="btn btn-primary"
+          >
+            Import
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/components/UtilitiesPage.vue
+++ b/frontend/src/components/UtilitiesPage.vue
@@ -6,20 +6,18 @@
     <h2 class="my-3">Utilities</h2>
     <div class="card card-body mb-4" v-if="stats">
       <h3 class="h5">Stats</h3>
-      <p>Total Models: {{ stats.totalModels }}</p>
-      <ul class="mb-3">
-        <li v-for="t in stats.typeCounts" :key="t.Key">
-          {{ t.Key || "Unknown" }}: {{ t.Count }}
-        </li>
-      </ul>
-      <div class="row">
-        <div class="col-md-6 mb-3">
+      <div class="row text-center">
+        <div class="col-md-4 mb-3">
+          <canvas id="typeChart"></canvas>
+        </div>
+        <div class="col-md-4 mb-3">
           <canvas id="baseModelChart"></canvas>
         </div>
-        <div class="col-md-6 mb-3">
+        <div class="col-md-4 mb-3">
           <canvas id="nsfwChart"></canvas>
         </div>
       </div>
+      <p class="text-center">Total Models: {{ stats.totalModels }}</p>
     </div>
     <h3 class="h5 mt-5">Import JSON from Model Organizer</h3>
     <div class="input-group mb-3">
@@ -102,6 +100,7 @@ import axios from "axios";
 import { showToast } from "../utils/ui";
 
 const stats = ref(null);
+let typeChart = null;
 let baseChart = null;
 let nsfwChart = null;
 
@@ -118,8 +117,24 @@ onMounted(async () => {
 
 function renderCharts() {
   if (!stats.value) return;
+  if (typeChart) typeChart.destroy();
   if (baseChart) baseChart.destroy();
   if (nsfwChart) nsfwChart.destroy();
+
+  const typeCtx = document.getElementById("typeChart");
+  if (typeCtx) {
+    typeChart = new Chart(typeCtx, {
+      type: "pie",
+      data: {
+        labels: stats.value.typeCounts.map((t) => t.Key || "Unknown"),
+        datasets: [
+          {
+            data: stats.value.typeCounts.map((t) => t.Count),
+          },
+        ],
+      },
+    });
+  }
 
   const baseCtx = document.getElementById("baseModelChart");
   if (baseCtx) {


### PR DESCRIPTION
## Summary
- add new `/api/stats` endpoint for model statistics
- include Chart.js and stats UI on Utilities page
- show pie charts of base models and NSFW distribution

## Testing
- `go vet ./...`
- `go build ./...`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688d13b5bf248332a3fd9e729ece9c2c