### PR TITLE
Fix metadata editor save functionality

### DIFF
--- a/frontend/src/components/ModelDetail.vue
+++ b/frontend/src/components/ModelDetail.vue
@@ -431,21 +431,24 @@ const cancelEdit = async () => {
 
 const saveEdit = async () => {
   if (quill) {
-    version.value.description = quill.root.innerHTML;
+    const desc = quill.root.innerHTML;
+    version.value.description = desc;
+    model.value.description = desc;
   }
-  await axios.put(`/api/models/${model.value.ID}`, model.value);
   try {
+    await axios.put(`/api/models/${model.value.ID}`, model.value);
     await axios.put(`/api/versions/${version.value.ID}`, version.value);
+    isEditing.value = false;
+    await fetchData();
+    showToast("Saved", "success");
   } catch (err) {
     if (err.response && err.response.status === 409) {
       showToast("Version ID already exists", "danger");
-      return;
+    } else {
+      console.error(err);
+      showToast("Failed to save", "danger");
     }
-    throw err;
   }
-  isEditing.value = false;
-  await fetchData();
-  showToast("Saved", "success");
 };
 
 const refreshVersion = async (fields) => {


### PR DESCRIPTION
## Summary
- Ensure metadata editor save button persists changes and exits edit mode
- Add error handling for save failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3dd79c08483329de942dc656b673a