### PR TITLE
Skip video previews in CivitAI downloads

### DIFF
--- a/backend/api/downloader.go
+++ b/backend/api/downloader.go
@@ -107,3 +107,19 @@ func FileHash(path string) (string, error) {
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
+
+// isVideoURL returns true if the provided URL points to a video file.
+// It checks the file extension against a list of common video formats
+// and is used to skip downloading preview videos from CivitAI.
+func isVideoURL(u string) bool {
+	// Strip query parameters before inspecting the extension
+	if idx := strings.Index(u, "?"); idx != -1 {
+		u = u[:idx]
+	}
+	ext := strings.ToLower(filepath.Ext(u))
+	switch ext {
+	case ".mp4", ".webm", ".avi", ".mov", ".mkv", ".flv", ".wmv", ".m4v", ".mpeg", ".mpg", ".gif":
+		return true
+	}
+	return false
+}

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -347,6 +347,9 @@ func SyncVersionByID(c *gin.Context) {
 		if imageURL == "" {
 			continue
 		}
+		if isVideoURL(imageURL) {
+			continue
+		}
 		imgPath, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
 		w, h, _ := GetImageDimensions(imgPath)
 		hash, _ := FileHash(imgPath)
@@ -455,6 +458,9 @@ func processModel(item CivitModel, apiKey string) {
 				imageURL = img.URLSmall
 			}
 			if imageURL == "" {
+				continue
+			}
+			if isVideoURL(imageURL) {
 				continue
 			}
 			imgPath, _ := DownloadFile(imageURL, "./backend/images/"+item.Type, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))

--- a/backend/api/refresh.go
+++ b/backend/api/refresh.go
@@ -111,6 +111,9 @@ func refreshVersionData(id int, fields string) error {
 			if imageURL == "" {
 				continue
 			}
+			if isVideoURL(imageURL) {
+				continue
+			}
 			imgPath, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
 			w, h, _ := GetImageDimensions(imgPath)
 			hash, _ := FileHash(imgPath)


### PR DESCRIPTION
## Summary
- add helper to detect video URLs
- prevent mp4/webm/other video formats from being saved as model images

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a60b88b8848332a1c510a0236eb49d