### PR TITLE
Move deleted files to OS trash

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -310,7 +310,7 @@ func SyncVersionByID(c *gin.Context) {
 		downloadURL = verData.ModelFiles[0].DownloadURL
 		filePath, _ = DownloadFile(downloadURL, "./backend/downloads/"+modelType, verData.ModelFiles[0].Name)
 		if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
-			os.Remove(filePath)
+			moveToTrash(filePath)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Downloaded file too small"})
 			return
 		}
@@ -423,7 +423,7 @@ func processModel(item CivitModel, apiKey string) {
 			fileName := verData.ModelFiles[0].Name
 			filePath, _ = DownloadFile(downloadURL, "./backend/downloads/"+item.Type, fileName)
 			if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
-				os.Remove(filePath)
+				moveToTrash(filePath)
 				log.Printf("downloaded %s is too small", fileName)
 				continue
 			}
@@ -529,23 +529,23 @@ func DeleteModel(c *gin.Context) {
 	}
 
 	if model.FilePath != "" {
-		os.Remove(model.FilePath)
+		moveToTrash(model.FilePath)
 	}
 	if model.ImagePath != "" {
-		os.Remove(model.ImagePath)
+		moveToTrash(model.ImagePath)
 	}
 	for _, v := range model.Versions {
 		if v.FilePath != "" {
-			os.Remove(v.FilePath)
+			moveToTrash(v.FilePath)
 		}
 		if v.ImagePath != "" {
-			os.Remove(v.ImagePath)
+			moveToTrash(v.ImagePath)
 		}
 		var imgs []models.VersionImage
 		database.DB.Where("version_id = ?", v.ID).Find(&imgs)
 		for _, img := range imgs {
 			if img.Path != "" {
-				os.Remove(img.Path)
+				moveToTrash(img.Path)
 			}
 		}
 		database.DB.Where("version_id = ?", v.ID).Delete(&models.VersionImage{})
@@ -603,14 +603,14 @@ func DeleteVersion(c *gin.Context) {
 
 	if deleteFiles {
 		if version.FilePath != "" {
-			os.Remove(version.FilePath)
+			moveToTrash(version.FilePath)
 		}
 		if version.ImagePath != "" {
-			os.Remove(version.ImagePath)
+			moveToTrash(version.ImagePath)
 		}
 		for _, img := range imgs {
 			if img.Path != "" {
-				os.Remove(img.Path)
+				moveToTrash(img.Path)
 			}
 		}
 	}
@@ -626,11 +626,11 @@ func DeleteVersion(c *gin.Context) {
 			var model models.Model
 			if err := database.DB.First(&model, version.ModelID).Error; err == nil {
 				if model.FilePath != "" && model.FilePath == version.FilePath {
-					os.Remove(model.FilePath)
+					moveToTrash(model.FilePath)
 					model.FilePath = ""
 				}
 				if model.ImagePath != "" && model.ImagePath == version.ImagePath {
-					os.Remove(model.ImagePath)
+					moveToTrash(model.ImagePath)
 					model.ImagePath = ""
 				}
 				database.DB.Save(&model)
@@ -1029,7 +1029,7 @@ func DeleteVersionImage(c *gin.Context) {
 	}
 
 	if image.Path != "" {
-		os.Remove(image.Path)
+		moveToTrash(image.Path)
 	}
 	database.DB.Delete(&image)
 

--- a/backend/api/refresh.go
+++ b/backend/api/refresh.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"model-manager/backend/database"
@@ -86,13 +85,13 @@ func refreshVersionData(id int, fields string) error {
 
 	if updateImages {
 		if version.ImagePath != "" {
-			os.Remove(version.ImagePath)
+			moveToTrash(version.ImagePath)
 		}
 		var imgs []models.VersionImage
 		database.DB.Where("version_id = ?", version.ID).Find(&imgs)
 		for _, img := range imgs {
 			if img.Path != "" {
-				os.Remove(img.Path)
+				moveToTrash(img.Path)
 			}
 		}
 		database.DB.Where("version_id = ?", version.ID).Delete(&models.VersionImage{})

--- a/backend/api/trash.go
+++ b/backend/api/trash.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// moveToTrash moves the given file to the operating system's trash/recycle bin.
+// It attempts to use platform-native mechanisms on Windows and macOS, and falls
+// back to the freedesktop.org trash specification on other systems (e.g. Linux).
+// If an error occurs, it is returned to the caller for handling.
+func moveToTrash(path string) error {
+	switch runtime.GOOS {
+	case "windows":
+		cmd := exec.Command("powershell", "-NoProfile", "-Command",
+			fmt.Sprintf(`Add-Type -AssemblyName Microsoft.VisualBasic; [Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile(%q, [Microsoft.VisualBasic.FileIO.UIOption]::OnlyErrorDialogs, [Microsoft.VisualBasic.FileIO.RecycleOption]::SendToRecycleBin)`, path))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("powershell recycle failed: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	case "darwin":
+		script := fmt.Sprintf(`tell application \"Finder\" to delete POSIX file %q`, path)
+		cmd := exec.Command("osascript", "-e", script)
+		return cmd.Run()
+	default:
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		filesDir := filepath.Join(home, ".local/share/Trash/files")
+		infoDir := filepath.Join(home, ".local/share/Trash/info")
+		if err := os.MkdirAll(filesDir, 0o755); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(infoDir, 0o755); err != nil {
+			return err
+		}
+		base := filepath.Base(abs)
+		dest := filepath.Join(filesDir, base)
+		for i := 1; ; i++ {
+			if _, err := os.Stat(dest); os.IsNotExist(err) {
+				break
+			}
+			dest = filepath.Join(filesDir, fmt.Sprintf("%s.%d", base, i))
+		}
+		if err := os.Rename(abs, dest); err != nil {
+			return err
+		}
+		infoPath := filepath.Join(infoDir, filepath.Base(dest)+".trashinfo")
+		u := url.PathEscape(abs)
+		ts := time.Now().Format("2006-01-02T15:04:05")
+		content := fmt.Sprintf("[Trash Info]\nPath=%s\nDeletionDate=%s\n", u, ts)
+		return os.WriteFile(infoPath, []byte(content), 0o644)
+	}
+}


### PR DESCRIPTION
## Summary
- Add cross-platform `moveToTrash` helper to recycle files via OS trash
- Replace direct deletions in model and image handlers with `moveToTrash`
- Update refresh process to trash existing images before replacement

## Testing
- `go fmt ./...`
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a69151c78c83329a9661bc0f1f16ce