### PR TITLE
test: add util tests for API key retrieval

### DIFF
--- a/backend/api/util_test.go
+++ b/backend/api/util_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"testing"
+
+	"bou.ke/monkey"
+	"model-manager/backend/database"
+)
+
+func TestGetCivitaiAPIKey(t *testing.T) {
+	t.Run("db overrides env", func(t *testing.T) {
+		t.Setenv("CIVIT_API_KEY", "envVal")
+		patch := monkey.Patch(database.GetSettingValue, func(key string) string {
+			if key != "civitai_api_key" {
+				t.Fatalf("unexpected key: %s", key)
+			}
+			return "dbVal"
+		})
+		defer patch.Unpatch()
+
+		if got := getCivitaiAPIKey(); got != "dbVal" {
+			t.Errorf("expected dbVal, got %s", got)
+		}
+	})
+
+	t.Run("env when db empty", func(t *testing.T) {
+		t.Setenv("CIVIT_API_KEY", "envVal")
+		patch := monkey.Patch(database.GetSettingValue, func(key string) string {
+			if key != "civitai_api_key" {
+				t.Fatalf("unexpected key: %s", key)
+			}
+			return ""
+		})
+		defer patch.Unpatch()
+
+		if got := getCivitaiAPIKey(); got != "envVal" {
+			t.Errorf("expected envVal, got %s", got)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module model-manager
 go 1.24.4
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/gin-gonic/gin v1.10.1
 	github.com/joho/godotenv v1.5.1
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=


### PR DESCRIPTION
## Summary
- add tests verifying getCivitaiAPIKey favors DB value over env
- add monkey patch dependency for stubbing database settings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce91daf08332b8b6f679bff0607f