### PR TITLE
Add Playwright end-to-end tests

### DIFF
--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"os"
+
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"model-manager/backend/models"
@@ -9,7 +11,11 @@ import (
 var DB *gorm.DB
 
 func ConnectDatabase() {
-	database, err := gorm.Open(sqlite.Open("backend/models.db"), &gorm.Config{})
+	path := os.Getenv("MODELS_DB_PATH")
+	if path == "" {
+		path = "backend/models.db"
+	}
+	database, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
 	if err != nil {
 		panic("Failed to connect to database")
 	}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@playwright/test": "^1.44.0",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/eslint-config-prettier": "^10.2.0",
         "autoprefixer": "^10.4.21",
@@ -1249,6 +1250,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -3937,6 +3954,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
@@ -29,6 +30,7 @@
     "postcss": "^8.5.6",
     "prettier": "3.5.3",
     "vite": "^6.3.5",
-    "vite-plugin-vue-devtools": "^7.7.7"
+    "vite-plugin-vue-devtools": "^7.7.7",
+    "@playwright/test": "^1.44.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+  webServer: {
+    command:
+      'bash -c "cd .. && rm -f backend/test.db && npm --prefix frontend run build && MODELS_DB_PATH=backend/test.db go run backend/main.go"',
+    port: 8080,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: "http://localhost:8080",
+  },
+});

--- a/frontend/tests/e2e.spec.ts
+++ b/frontend/tests/e2e.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+// Mock external API calls to keep tests deterministic
+test.beforeEach(async ({ page }) => {
+  await page.route("**/civitai.com/**", (route) => {
+    return route.fulfill({ status: 200, body: "{}" });
+  });
+});
+
+test("navigate between routes and SPA fallback", async ({ page }) => {
+  await page.goto("/");
+  await page.click('a[href="#/utilities"]');
+  await expect(page.locator("h2")).toHaveText("Utilities");
+
+  await page.click('a[href="#/settings"]');
+  await expect(page.locator("h2")).toHaveText("Settings");
+
+  await page.click('a[href="#/"]');
+  await expect(
+    page.locator('input[placeholder="Search models..."]'),
+  ).toBeVisible();
+
+  await page.goto("/non-existent");
+  await expect(
+    page.locator('input[placeholder="Search models..."]'),
+  ).toBeVisible();
+});
+
+test("add model via UI and verify in list", async ({ page }) => {
+  await page.goto("/");
+  await page.click("text=Add Models");
+  await page.click("text=Add Model");
+
+  await page
+    .locator('label:has-text("Name") + input')
+    .first()
+    .fill("Test Model");
+  await page.locator('label:has-text("Version Name") + input').fill("v1");
+  await page.click("text=Save");
+  await page.click("text=Back");
+
+  await expect(
+    page.locator(".card").filter({ hasText: "Test Model" }),
+  ).toBeVisible();
+});
+
+test("update settings and ensure persistence", async ({ page }) => {
+  await page.goto("/");
+  await page.click('a[href="#/settings"]');
+
+  const apiKeyInput = page.locator('input[type="text"]');
+  await apiKeyInput.fill("my-test-key");
+  await page.click("text=Save");
+
+  await page.click('a[href="#/"]');
+  await page.click('a[href="#/settings"]');
+
+  await expect(page.locator('input[type="text"]')).toHaveValue("my-test-key");
+});


### PR DESCRIPTION
## Summary
- allow backend to use MODELS_DB_PATH for configurable test database
- add Playwright setup and e2e scenarios for routing, model creation, and settings persistence

## Testing
- `go test ./...`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a7ec40e0288332b91acb293d960b78