### PR TITLE
Add cross-platform trash tests

### DIFF
--- a/backend/api/trash.go
+++ b/backend/api/trash.go
@@ -11,12 +11,14 @@ import (
 	"time"
 )
 
+var runtimeGOOS = runtime.GOOS
+
 // moveToTrash moves the given file to the operating system's trash/recycle bin.
 // It attempts to use platform-native mechanisms on Windows and macOS, and falls
 // back to the freedesktop.org trash specification on other systems (e.g. Linux).
 // If an error occurs, it is returned to the caller for handling.
 func moveToTrash(path string) error {
-	switch runtime.GOOS {
+	switch runtimeGOOS {
 	case "windows":
 		cmd := exec.Command("powershell", "-NoProfile", "-Command",
 			fmt.Sprintf(`Add-Type -AssemblyName Microsoft.VisualBasic; [Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile(%q, [Microsoft.VisualBasic.FileIO.UIOption]::OnlyErrorDialogs, [Microsoft.VisualBasic.FileIO.RecycleOption]::SendToRecycleBin)`, path))

--- a/backend/api/trash_darwin_test.go
+++ b/backend/api/trash_darwin_test.go
@@ -1,0 +1,13 @@
+//go:build trash_darwin
+// +build trash_darwin
+
+package api
+
+import "testing"
+
+func TestMoveToTrashDarwin(t *testing.T) {
+	old := runtimeGOOS
+	runtimeGOOS = "darwin"
+	defer func() { runtimeGOOS = old }()
+	testDarwinTrash(t)
+}

--- a/backend/api/trash_test.go
+++ b/backend/api/trash_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testUnixTrash(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	file := filepath.Join(tmpHome, "example.txt")
+	if err := os.WriteFile(file, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if err := moveToTrash(file); err != nil {
+		t.Fatalf("moveToTrash: %v", err)
+	}
+	dest := filepath.Join(tmpHome, ".local/share/Trash/files/example.txt")
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("expected file moved: %v", err)
+	}
+	info := filepath.Join(tmpHome, ".local/share/Trash/info/example.txt.trashinfo")
+	b, err := os.ReadFile(info)
+	if err != nil {
+		t.Fatalf("read info: %v", err)
+	}
+	if !strings.Contains(string(b), "Path="+url.PathEscape(file)) {
+		t.Fatalf("info missing path: %s", b)
+	}
+	if !strings.Contains(string(b), "DeletionDate=") {
+		t.Fatalf("info missing deletion date: %s", b)
+	}
+}
+
+func testWindowsTrash(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "log")
+	psPath := filepath.Join(tmp, "powershell")
+	script := fmt.Sprintf("#!/bin/sh\necho $@ > %s\n", logPath)
+	if err := os.WriteFile(psPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", tmp+":"+os.Getenv("PATH"))
+	file := filepath.Join(tmp, "example.txt")
+	if err := os.WriteFile(file, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := moveToTrash(file); err != nil {
+		t.Fatalf("moveToTrash: %v", err)
+	}
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(b), file) {
+		t.Fatalf("powershell not called with file: %s", b)
+	}
+}
+
+func testDarwinTrash(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "log")
+	osaPath := filepath.Join(tmp, "osascript")
+	script := fmt.Sprintf("#!/bin/sh\necho $@ > %s\n", logPath)
+	if err := os.WriteFile(osaPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", tmp+":"+os.Getenv("PATH"))
+	file := filepath.Join(tmp, "example.txt")
+	if err := os.WriteFile(file, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := moveToTrash(file); err != nil {
+		t.Fatalf("moveToTrash: %v", err)
+	}
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(b), file) {
+		t.Fatalf("osascript not called with file: %s", b)
+	}
+}

--- a/backend/api/trash_unix_test.go
+++ b/backend/api/trash_unix_test.go
@@ -1,0 +1,13 @@
+//go:build !trash_windows && !trash_darwin
+// +build !trash_windows,!trash_darwin
+
+package api
+
+import "testing"
+
+func TestMoveToTrashUnix(t *testing.T) {
+	old := runtimeGOOS
+	runtimeGOOS = "linux"
+	defer func() { runtimeGOOS = old }()
+	testUnixTrash(t)
+}

--- a/backend/api/trash_windows_test.go
+++ b/backend/api/trash_windows_test.go
@@ -1,0 +1,13 @@
+//go:build trash_windows
+// +build trash_windows
+
+package api
+
+import "testing"
+
+func TestMoveToTrashWindows(t *testing.T) {
+	old := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = old }()
+	testWindowsTrash(t)
+}


### PR DESCRIPTION
## Summary
- Allow moveToTrash to override GOOS for testing
- Add OS-specific trash tests with build tags and command stubs

## Testing
- `go test ./backend/api -run TestMoveToTrashUnix -count=1`
- `go test -tags trash_windows ./backend/api -run TestMoveToTrashWindows -count=1` *(no tests to run: build tag restriction)*
- `go test -tags trash_darwin ./backend/api -run TestMoveToTrashDarwin -count=1` *(no tests to run: build tag restriction)*
- `go test ./backend/api`

------
https://chatgpt.com/codex/tasks/task_e_68a7ec1b0df8833296ae22b07fc162ed