### PR TITLE
Add endpoint to list orphaned downloaded files

### DIFF
--- a/backend/api/orphans.go
+++ b/backend/api/orphans.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"io/fs"
+	"net/http"
+	"path/filepath"
+
+	"model-manager/backend/database"
+	"model-manager/backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetOrphanedFiles returns file paths in backend/downloads that are not referenced in the database.
+func GetOrphanedFiles(c *gin.Context) {
+	// Collect file paths from models and versions
+	var modelPaths []string
+	database.DB.Model(&models.Model{}).Where("file_path <> ''").Pluck("file_path", &modelPaths)
+	var versionPaths []string
+	database.DB.Model(&models.Version{}).Where("file_path <> ''").Pluck("file_path", &versionPaths)
+
+	dbFiles := make(map[string]struct{})
+	for _, p := range append(modelPaths, versionPaths...) {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		dbFiles[abs] = struct{}{}
+	}
+
+	var orphans []string
+	root := "./backend/downloads"
+	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil
+		}
+		if _, exists := dbFiles[abs]; !exists {
+			orphans = append(orphans, abs)
+		}
+		return nil
+	})
+
+	c.JSON(http.StatusOK, gin.H{"orphans": orphans})
+}

--- a/backend/api/orphans_test.go
+++ b/backend/api/orphans_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"model-manager/backend/database"
+	"model-manager/backend/models"
+)
+
+// setupOrphansTest prepares a temporary downloads directory and in-memory database.
+func setupOrphansTest(t *testing.T) string {
+	t.Helper()
+
+	// Use a unique in-memory database for each test
+	dbPath := "file:" + t.Name() + "?mode=memory&cache=shared"
+	t.Setenv("MODELS_DB_PATH", dbPath)
+	database.ConnectDatabase()
+
+	// Switch to repository root so the handler's relative path is correct
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir("../.."); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(wd)
+		os.RemoveAll("backend/downloads")
+	})
+
+	if err := os.MkdirAll("backend/downloads/sub", 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	files := []string{
+		"backend/downloads/a.bin",
+		"backend/downloads/b.bin",
+		"backend/downloads/sub/c.bin",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte("test"), 0o644); err != nil {
+			t.Fatalf("write file %s: %v", f, err)
+		}
+	}
+	return "backend/downloads/sub/c.bin"
+}
+
+func TestGetOrphanedFiles(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	orphan := setupOrphansTest(t)
+
+	// Insert referenced files into DB
+	absA, _ := filepath.Abs("backend/downloads/a.bin")
+	absB, _ := filepath.Abs("backend/downloads/b.bin")
+	m := models.Model{CivitID: 1, Name: "m1", FilePath: absA}
+	if err := database.DB.Create(&m).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if err := database.DB.Create(&models.Version{ModelID: m.ID, VersionID: 1, FilePath: absB}).Error; err != nil {
+		t.Fatalf("create version: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/api/orphaned-files", GetOrphanedFiles)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/orphaned-files", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Orphans []string `json:"orphans"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Orphans) != 1 {
+		t.Fatalf("got %d orphans, want 1", len(resp.Orphans))
+	}
+	absOrphan, _ := filepath.Abs(orphan)
+	if resp.Orphans[0] != absOrphan {
+		t.Errorf("orphan = %s, want %s", resp.Orphans[0], absOrphan)
+	}
+}
+
+func TestGetOrphanedFilesNone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setupOrphansTest(t)
+
+	absA, _ := filepath.Abs("backend/downloads/a.bin")
+	absB, _ := filepath.Abs("backend/downloads/b.bin")
+	absC, _ := filepath.Abs("backend/downloads/sub/c.bin")
+
+	m := models.Model{CivitID: 1, Name: "m1", FilePath: absA}
+	if err := database.DB.Create(&m).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	versions := []models.Version{
+		{ModelID: m.ID, VersionID: 1, FilePath: absB},
+		{ModelID: m.ID, VersionID: 2, FilePath: absC},
+	}
+	if err := database.DB.Create(&versions).Error; err != nil {
+		t.Fatalf("create versions: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/api/orphaned-files", GetOrphanedFiles)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/orphaned-files", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		Orphans []string `json:"orphans"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Orphans) != 0 {
+		t.Fatalf("got %d orphans, want 0", len(resp.Orphans))
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -50,6 +50,7 @@ func main() {
 		apiGroup.POST("/import-db", api.ImportDatabase)
 		apiGroup.GET("/export", api.ExportModels)
 		apiGroup.GET("/stats", api.GetStats)
+		apiGroup.GET("/orphaned-files", api.GetOrphanedFiles)
 		apiGroup.GET("/settings", api.GetSettings)
 		apiGroup.POST("/settings", api.UpdateSetting)
 	}


### PR DESCRIPTION
## Summary
- expose `GET /api/orphaned-files` to list files in backend/downloads that are not referenced by any model or version
- gather file paths from database and walk downloads directory to identify orphans
- test coverage for endpoint including no-orphan case

## Testing
- `go fmt ./backend/...`
- `go build ./backend/...`
- `go test ./backend/...`


------
https://chatgpt.com/codex/tasks/task_e_68a944e47bf88332bbbdc29e43b8f2cf