### PR TITLE
Avoid filename collisions when syncing versions

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -310,8 +310,16 @@ func SyncVersionByID(c *gin.Context) {
 	}
 	if len(verData.ModelFiles) > 0 {
 		downloadURL = verData.ModelFiles[0].DownloadURL
+		fileName := verData.ModelFiles[0].Name
+		destDir := "./backend/downloads/" + modelType
+		destPath := filepath.Join(destDir, fileName)
 		if shouldDownload {
-			filePath, _ = DownloadFile(downloadURL, "./backend/downloads/"+modelType, verData.ModelFiles[0].Name)
+			if _, err := os.Stat(destPath); err == nil {
+				ext := filepath.Ext(fileName)
+				base := strings.TrimSuffix(fileName, ext)
+				fileName = fmt.Sprintf("%s_%d%s", base, verData.ID, ext)
+			}
+			filePath, _ = DownloadFile(downloadURL, destDir, fileName)
 			if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
 				moveToTrash(filePath)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Downloaded file too small"})
@@ -425,7 +433,14 @@ func processModel(item CivitModel, apiKey string) {
 		if len(verData.ModelFiles) > 0 {
 			downloadURL = verData.ModelFiles[0].DownloadURL
 			fileName := verData.ModelFiles[0].Name
-			filePath, _ = DownloadFile(downloadURL, "./backend/downloads/"+item.Type, fileName)
+			destDir := "./backend/downloads/" + item.Type
+			destPath := filepath.Join(destDir, fileName)
+			if _, err := os.Stat(destPath); err == nil {
+				ext := filepath.Ext(fileName)
+				base := strings.TrimSuffix(fileName, ext)
+				fileName = fmt.Sprintf("%s_%d%s", base, verData.ID, ext)
+			}
+			filePath, _ = DownloadFile(downloadURL, destDir, fileName)
 			if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
 				moveToTrash(filePath)
 				log.Printf("downloaded %s is too small", fileName)


### PR DESCRIPTION
## Summary
- Check target download path for existing file before downloading a model version
- Append the version ID to the filename when a conflict is detected
- Check existing file paths in `processModel` to avoid overwriting files during bulk processing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68adafaa58f083329cb95eca94fb8b4b