### PR TITLE
Avoid overwriting existing downloads

### DIFF
--- a/backend/api/downloader_test.go
+++ b/backend/api/downloader_test.go
@@ -46,9 +46,12 @@ func TestDownloadFileAndHelpers(t *testing.T) {
 
 	destDir := filepath.Join(t.TempDir(), "downloads")
 
-	filePath, err := DownloadFile(srv.URL+"/file", destDir, "test.txt")
+	filePath, size, err := DownloadFile(srv.URL+"/file", destDir, "test.txt")
 	if err != nil {
 		t.Fatalf("DownloadFile file: %v", err)
+	}
+	if size != int64(len(fileContent)) {
+		t.Errorf("size = %d, want %d", size, len(fileContent))
 	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
@@ -72,9 +75,12 @@ func TestDownloadFileAndHelpers(t *testing.T) {
 		t.Errorf("hash = %s, want %s", hash, hex.EncodeToString(expHash[:]))
 	}
 
-	imgPath, err := DownloadFile(srv.URL+"/image", destDir, "img.png")
+	imgPath, imgSize, err := DownloadFile(srv.URL+"/image", destDir, "img.png")
 	if err != nil {
 		t.Fatalf("DownloadFile image: %v", err)
+	}
+	if imgSize != int64(len(imgBytes)) {
+		t.Errorf("image size = %d, want %d", imgSize, len(imgBytes))
 	}
 	w, h, err := GetImageDimensions(imgPath)
 	if err != nil {

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -301,6 +301,7 @@ func SyncVersionByID(c *gin.Context) {
 	}
 
 	var filePath, imagePath string
+	var size int64
 	var imgW, imgH int
 	var fileSHA string
 	var downloadURL string
@@ -319,8 +320,8 @@ func SyncVersionByID(c *gin.Context) {
 				base := strings.TrimSuffix(fileName, ext)
 				fileName = fmt.Sprintf("%s_%d%s", base, verData.ID, ext)
 			}
-			filePath, _ = DownloadFile(downloadURL, destDir, fileName)
-			if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
+			filePath, size, _ = DownloadFile(downloadURL, destDir, fileName)
+			if size < 110 {
 				moveToTrash(filePath)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Downloaded file too small"})
 				return
@@ -362,7 +363,7 @@ func SyncVersionByID(c *gin.Context) {
 		if isVideoURL(imageURL) {
 			continue
 		}
-		imgPath, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
+		imgPath, _, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
 		w, h, _ := GetImageDimensions(imgPath)
 		hash, _ := FileHash(imgPath)
 		metaBytes, _ := json.Marshal(img.Meta)
@@ -427,6 +428,7 @@ func processModel(item CivitModel, apiKey string) {
 		}
 
 		var filePath, imagePath string
+		var size int64
 		var imgW, imgH int
 		var fileSHA string
 		var downloadURL string
@@ -440,8 +442,8 @@ func processModel(item CivitModel, apiKey string) {
 				base := strings.TrimSuffix(fileName, ext)
 				fileName = fmt.Sprintf("%s_%d%s", base, verData.ID, ext)
 			}
-			filePath, _ = DownloadFile(downloadURL, destDir, fileName)
-			if info, err := os.Stat(filePath); err == nil && info.Size() < 110 {
+			filePath, size, _ = DownloadFile(downloadURL, destDir, fileName)
+			if size < 110 {
 				moveToTrash(filePath)
 				log.Printf("downloaded %s is too small", fileName)
 				continue
@@ -482,7 +484,7 @@ func processModel(item CivitModel, apiKey string) {
 			if isVideoURL(imageURL) {
 				continue
 			}
-			imgPath, _ := DownloadFile(imageURL, "./backend/images/"+item.Type, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
+			imgPath, _, _ := DownloadFile(imageURL, "./backend/images/"+item.Type, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
 			w, h, _ := GetImageDimensions(imgPath)
 			hash, _ := FileHash(imgPath)
 			metaBytes, _ := json.Marshal(img.Meta)

--- a/backend/api/refresh.go
+++ b/backend/api/refresh.go
@@ -113,7 +113,7 @@ func refreshVersionData(id int, fields string) error {
 			if isVideoURL(imageURL) {
 				continue
 			}
-			imgPath, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
+			imgPath, _, _ := DownloadFile(imageURL, "./backend/images/"+modelType, fmt.Sprintf("%d_%d.jpg", verData.ID, idx))
 			w, h, _ := GetImageDimensions(imgPath)
 			hash, _ := FileHash(imgPath)
 			metaBytes, _ := json.Marshal(img.Meta)


### PR DESCRIPTION
## Summary
- Restore file size validation to skip tiny downloads
- Prevent model downloads from overwriting existing files by appending version ID
- Expose bytes written from `DownloadFile` to enable size checks without extra stat calls

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bcce9ae51c8332a1ca9e228c9b2b65