### PR TITLE
Prefer safetensors models from Civitai

### DIFF
--- a/backend/api/file_select.go
+++ b/backend/api/file_select.go
@@ -1,0 +1,18 @@
+package api
+
+import "strings"
+
+// selectModelFile returns the preferred model file from the provided list.
+// It chooses a file with a .safetensors extension when available,
+// otherwise it falls back to the first file in the slice.
+func selectModelFile(files []ModelFile) ModelFile {
+	if len(files) == 0 {
+		return ModelFile{}
+	}
+	for _, f := range files {
+		if strings.HasSuffix(strings.ToLower(f.Name), ".safetensors") {
+			return f
+		}
+	}
+	return files[0]
+}

--- a/backend/api/file_select_test.go
+++ b/backend/api/file_select_test.go
@@ -1,0 +1,24 @@
+package api
+
+import "testing"
+
+func TestSelectModelFile(t *testing.T) {
+	files := []ModelFile{
+		{Name: "model.ckpt"},
+		{Name: "model.safetensors"},
+		{Name: "model.pt"},
+	}
+	f := selectModelFile(files)
+	if f.Name != "model.safetensors" {
+		t.Fatalf("expected safetensors, got %s", f.Name)
+	}
+
+	files = []ModelFile{
+		{Name: "model.ckpt"},
+		{Name: "model.pt"},
+	}
+	f = selectModelFile(files)
+	if f.Name != "model.ckpt" {
+		t.Fatalf("expected first file, got %s", f.Name)
+	}
+}

--- a/backend/api/refresh.go
+++ b/backend/api/refresh.go
@@ -59,9 +59,10 @@ func refreshVersionData(id int, fields string) error {
 		version.BaseModel = verData.BaseModel
 		version.EarlyAccessTimeFrame = verData.EarlyAccessTimeFrame
 		if len(verData.ModelFiles) > 0 {
-			version.SizeKB = verData.ModelFiles[0].SizeKB
-			version.SHA256 = verData.ModelFiles[0].Hashes.SHA256
-			version.DownloadURL = verData.ModelFiles[0].DownloadURL
+			file := selectModelFile(verData.ModelFiles)
+			version.SizeKB = file.SizeKB
+			version.SHA256 = file.Hashes.SHA256
+			version.DownloadURL = file.DownloadURL
 		}
 		version.TrainedWords = strings.Join(verData.TrainedWords, ",")
 		version.Nsfw = modelData.Nsfw


### PR DESCRIPTION
## Summary
- Prefer `.safetensors` files when multiple Civitai model files are available
- Refactor download and metadata routines to use the preferred file
- Add unit test for model file selection

## Testing
- `go test ./backend/... && echo TESTS-PASSED`


------
https://chatgpt.com/codex/tasks/task_e_68bd8acdcd688332b66e753a8e55eb56