### PR TITLE
Expand model search to version names and trained terms

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -39,14 +39,15 @@ func GetModels(c *gin.Context) {
 	var modelsList []models.Model
 	q := database.DB.Model(&models.Model{})
 
-	// Filter models by versions when filters are provided
-	needJoin := baseModel != "" || modelType != "" || hideNsfw || tags != ""
+	// Filter models by versions when filters are provided or when searching
+	needJoin := search != "" || baseModel != "" || modelType != "" || hideNsfw || tags != ""
 	if needJoin {
 		q = q.Joins("JOIN versions ON versions.model_id = models.id")
 	}
 
 	if search != "" {
-		q = q.Where("LOWER(models.name) LIKE ?", "%"+strings.ToLower(search)+"%")
+		like := "%" + strings.ToLower(search) + "%"
+		q = q.Where("LOWER(models.name) LIKE ? OR LOWER(versions.name) LIKE ? OR LOWER(versions.trained_words) LIKE ?", like, like, like)
 	}
 	if baseModel != "" {
 		q = q.Where("versions.base_model = ?", baseModel)
@@ -107,12 +108,13 @@ func GetModelsCount(c *gin.Context) {
 
 	var count int64
 	q := database.DB.Model(&models.Model{})
-	needJoin := baseModel != "" || modelType != "" || hideNsfw || tags != ""
+	needJoin := search != "" || baseModel != "" || modelType != "" || hideNsfw || tags != ""
 	if needJoin {
 		q = q.Joins("JOIN versions ON versions.model_id = models.id")
 	}
 	if search != "" {
-		q = q.Where("LOWER(models.name) LIKE ?", "%"+strings.ToLower(search)+"%")
+		like := "%" + strings.ToLower(search) + "%"
+		q = q.Where("LOWER(models.name) LIKE ? OR LOWER(versions.name) LIKE ? OR LOWER(versions.trained_words) LIKE ?", like, like, like)
 	}
 	if baseModel != "" {
 		q = q.Where("versions.base_model = ?", baseModel)

--- a/backend/api/handlers_list_test.go
+++ b/backend/api/handlers_list_test.go
@@ -21,7 +21,7 @@ func setupListDB(t *testing.T) {
 	if err := database.DB.Create(&m1).Error; err != nil {
 		t.Fatalf("create model1: %v", err)
 	}
-	if err := database.DB.Create(&models.Version{ModelID: m1.ID, VersionID: 11, BaseModel: "SD1", Type: "checkpoint", Nsfw: false, Tags: "tag1"}).Error; err != nil {
+	if err := database.DB.Create(&models.Version{ModelID: m1.ID, VersionID: 11, Name: "AlphaV1", BaseModel: "SD1", Type: "checkpoint", Nsfw: false, Tags: "tag1", TrainedWords: "alpha-key"}).Error; err != nil {
 		t.Fatalf("create version1: %v", err)
 	}
 
@@ -29,7 +29,7 @@ func setupListDB(t *testing.T) {
 	if err := database.DB.Create(&m2).Error; err != nil {
 		t.Fatalf("create model2: %v", err)
 	}
-	if err := database.DB.Create(&models.Version{ModelID: m2.ID, VersionID: 22, BaseModel: "SD1", Type: "lora", Nsfw: true, Tags: "tag2,tag3"}).Error; err != nil {
+	if err := database.DB.Create(&models.Version{ModelID: m2.ID, VersionID: 22, Name: "BetaSpecial", BaseModel: "SD1", Type: "lora", Nsfw: true, Tags: "tag2,tag3", TrainedWords: "beta-key"}).Error; err != nil {
 		t.Fatalf("create version2: %v", err)
 	}
 
@@ -37,7 +37,7 @@ func setupListDB(t *testing.T) {
 	if err := database.DB.Create(&m3).Error; err != nil {
 		t.Fatalf("create model3: %v", err)
 	}
-	if err := database.DB.Create(&models.Version{ModelID: m3.ID, VersionID: 33, BaseModel: "SD2", Type: "checkpoint", Nsfw: false, Tags: "tag1,tag2"}).Error; err != nil {
+	if err := database.DB.Create(&models.Version{ModelID: m3.ID, VersionID: 33, Name: "GammaVer", BaseModel: "SD2", Type: "checkpoint", Nsfw: false, Tags: "tag1,tag2", TrainedWords: "gamma-key"}).Error; err != nil {
 		t.Fatalf("create version3: %v", err)
 	}
 
@@ -45,7 +45,7 @@ func setupListDB(t *testing.T) {
 	if err := database.DB.Create(&m4).Error; err != nil {
 		t.Fatalf("create model4: %v", err)
 	}
-	if err := database.DB.Create(&models.Version{ModelID: m4.ID, VersionID: 44, BaseModel: "SD2", Type: "lora", Nsfw: false, Tags: "tag3"}).Error; err != nil {
+	if err := database.DB.Create(&models.Version{ModelID: m4.ID, VersionID: 44, Name: "DeltaVer", BaseModel: "SD2", Type: "lora", Nsfw: false, Tags: "tag3", TrainedWords: "delta-key"}).Error; err != nil {
 		t.Fatalf("create version4: %v", err)
 	}
 }
@@ -68,6 +68,8 @@ func TestGetModelsAndCountFilters(t *testing.T) {
 		wantNames []string
 	}{
 		{"search", "?search=alpha", []string{"Alpha"}},
+		{"searchVersion", "?search=betaspecial", []string{"Beta"}},
+		{"searchTrained", "?search=delta-key", []string{"Delta"}},
 		{"baseModel", "?baseModel=SD1", []string{"Beta", "Alpha"}},
 		{"modelType", "?modelType=lora", []string{"Delta", "Beta"}},
 		{"hideNsfw", "?hideNsfw=1", []string{"Delta", "Gamma", "Alpha"}},

--- a/frontend/src/components/ModelList.vue
+++ b/frontend/src/components/ModelList.vue
@@ -670,11 +670,17 @@ const totalPages = computed(() => Math.ceil(total.value / limit));
 const filteredModels = computed(() => {
   return models.value.filter((m) => {
     if (hideNsfw.value && m.nsfw) return false;
-    if (
-      search.value &&
-      !m.name.toLowerCase().includes(search.value.toLowerCase())
-    )
-      return false;
+    if (search.value) {
+      const s = search.value.toLowerCase();
+      const matchModel = m.name.toLowerCase().includes(s);
+      const matchVersion = (m.versions || []).some((v) =>
+        v.name.toLowerCase().includes(s),
+      );
+      const matchTrained = (m.versions || []).some((v) =>
+        (v.trainedWords || "").toLowerCase().includes(s),
+      );
+      if (!(matchModel || matchVersion || matchTrained)) return false;
+    }
     return true;
   });
 });
@@ -694,6 +700,13 @@ const versionCards = computed(() => {
         if (selectedModelType.value && v.type !== selectedModelType.value)
           return false;
         if (hideNsfw.value && v.nsfw) return false;
+        if (search.value) {
+          const s = search.value.toLowerCase();
+          const matchModel = model.name.toLowerCase().includes(s);
+          const matchVersion = v.name.toLowerCase().includes(s);
+          const matchTrained = (v.trainedWords || "").toLowerCase().includes(s);
+          if (!(matchModel || matchVersion || matchTrained)) return false;
+        }
 
         if (selectedCategory.value) {
           const tags = (v.tags || "")


### PR DESCRIPTION
## Summary
- Search endpoint now joins model versions and matches against model names, version names, and trained words
- Allow UI search box to filter models and versions by version name or trained words
- Test coverage for searching by version name and trained words

## Testing
- `npm run lint`
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c258896d0c8332b1a67bb3222920ef