### PR TITLE
Add comprehensive tests for model file selection

### DIFF
--- a/backend/api/file_select_test.go
+++ b/backend/api/file_select_test.go
@@ -2,23 +2,59 @@ package api
 
 import "testing"
 
+// TestSelectModelFile verifies the selection logic for ModelFile slices.
 func TestSelectModelFile(t *testing.T) {
-	files := []ModelFile{
-		{Name: "model.ckpt"},
-		{Name: "model.safetensors"},
-		{Name: "model.pt"},
-	}
-	f := selectModelFile(files)
-	if f.Name != "model.safetensors" {
-		t.Fatalf("expected safetensors, got %s", f.Name)
-	}
+	t.Run("prefers safetensors when available", func(t *testing.T) {
+		files := []ModelFile{
+			{Name: "model.ckpt"},
+			{Name: "model.safetensors"},
+			{Name: "model.pt"},
+		}
+		f := selectModelFile(files)
+		if f.Name != "model.safetensors" {
+			t.Fatalf("expected safetensors, got %s", f.Name)
+		}
+	})
 
-	files = []ModelFile{
-		{Name: "model.ckpt"},
-		{Name: "model.pt"},
-	}
-	f = selectModelFile(files)
-	if f.Name != "model.ckpt" {
-		t.Fatalf("expected first file, got %s", f.Name)
-	}
+	t.Run("falls back to first file when no safetensors", func(t *testing.T) {
+		files := []ModelFile{
+			{Name: "model.ckpt"},
+			{Name: "model.pt"},
+		}
+		f := selectModelFile(files)
+		if f.Name != "model.ckpt" {
+			t.Fatalf("expected first file, got %s", f.Name)
+		}
+	})
+
+	t.Run("returns zero value for empty slice", func(t *testing.T) {
+		var files []ModelFile
+		f := selectModelFile(files)
+		if (f != ModelFile{}) {
+			t.Fatalf("expected zero value, got %+v", f)
+		}
+	})
+
+	t.Run("selects first safetensors deterministically", func(t *testing.T) {
+		files := []ModelFile{
+			{Name: "first.safetensors"},
+			{Name: "second.safetensors"},
+			{Name: "model.pt"},
+		}
+		f := selectModelFile(files)
+		if f.Name != "first.safetensors" {
+			t.Fatalf("expected first safetensors, got %s", f.Name)
+		}
+	})
+
+	t.Run("unsupported extensions fall back to first file", func(t *testing.T) {
+		files := []ModelFile{
+			{Name: "model.txt"},
+			{Name: "model.doc"},
+		}
+		f := selectModelFile(files)
+		if f.Name != "model.txt" {
+			t.Fatalf("expected first file, got %s", f.Name)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- expand `selectModelFile` tests to cover empty slices
- ensure first `.safetensors` is deterministically chosen
- verify fallback behavior for unsupported extensions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3a0719478833291cf70b45f18751b