### PR TITLE
Improve CivitAI image selection

### DIFF
--- a/backend/api/refresh.go
+++ b/backend/api/refresh.go
@@ -103,7 +103,7 @@ func refreshVersionData(id int, fields string) error {
 		if modelType == "" {
 			modelType = modelData.Type
 		}
-		images := collectVersionImages(apiKey, verData)
+		images := collectVersionImages(apiKey, verData, modelType)
 		for idx, img := range images {
 			imageURL := img.URL
 			if imageURL == "" {

--- a/backend/api/types.go
+++ b/backend/api/types.go
@@ -48,12 +48,15 @@ type ModelFile struct {
 }
 
 type ModelImage struct {
-	URL      string                 `json:"url"`
-	URLSmall string                 `json:"urlSmall"`
-	Width    int                    `json:"width"`
-	Height   int                    `json:"height"`
-	Hash     string                 `json:"hash"`
-	Meta     map[string]interface{} `json:"meta"`
+	ID              int                    `json:"id"`
+	URL             string                 `json:"url"`
+	URLSmall        string                 `json:"urlSmall"`
+	Width           int                    `json:"width"`
+	Height          int                    `json:"height"`
+	Hash            string                 `json:"hash"`
+	Type            string                 `json:"type"`
+	ModelVersionIDs []int                  `json:"modelVersionIds"`
+	Meta            map[string]interface{} `json:"meta"`
 }
 
 type imagesResponse struct {


### PR DESCRIPTION
## Summary
- expand the CivitAI model image representation to capture ids, types, and version references
- refactor version image fetching to request metadata, deduplicate responses, and filter entries to the active model version
- update image collection callers to pass the model type and gracefully fall back to filtered version metadata when needed

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3fcb3bd78833294282b69fa215a05