### PR TITLE
Use model version images instead of images endpoint

### DIFF
--- a/backend/api/civitai.go
+++ b/backend/api/civitai.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	neturl "net/url"
 )
 
 // FetchCivitModels calls the CivitAI REST API using the provided apiKey and
@@ -77,57 +76,4 @@ func FetchModelVersion(apiKey string, versionID int) (VersionResponse, error) {
 	body, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(body, &version)
 	return version, err
-}
-
-// FetchVersionImages retrieves the images associated with a specific model version
-// using the paginated CivitAI images endpoint. It aggregates all pages, returning
-// a slice of ModelImage entries or an error when the request fails.
-func FetchVersionImages(apiKey string, versionID int) ([]ModelImage, error) {
-	var images []ModelImage
-	cursor := ""
-
-	for {
-		url := fmt.Sprintf("https://civitai.com/api/v1/images?modelVersionId=%d&limit=100", versionID)
-		if cursor != "" {
-			url += "&cursor=" + neturl.QueryEscape(cursor)
-		}
-
-		log.Printf("GET %s", url)
-
-		req, _ := http.NewRequest("GET", url, nil)
-		if apiKey != "" {
-			req.Header.Add("Authorization", "Bearer "+apiKey)
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			return nil, fmt.Errorf("failed to fetch images for version %d", versionID)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		var parsed imagesResponse
-		if err := json.Unmarshal(body, &parsed); err != nil {
-			return nil, err
-		}
-
-		if len(parsed.Items) > 0 {
-			images = append(images, parsed.Items...)
-		}
-
-		if parsed.Metadata.NextCursor == "" {
-			break
-		}
-		cursor = parsed.Metadata.NextCursor
-	}
-
-	return images, nil
 }

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -312,16 +312,8 @@ func fetchVersionDetails(apiKey string, versionID int, fallbackModelID int) (Ver
 	return VersionResponse{}, errVersionSummaryNotFound
 }
 
-func collectVersionImages(apiKey string, verData VersionResponse) []ModelImage {
-	fetched, err := FetchVersionImages(apiKey, verData.ID)
-	if err != nil {
-		log.Printf("Failed to fetch images for version %d: %v", verData.ID, err)
-		return verData.Images
-	}
-	if len(fetched) == 0 {
-		return verData.Images
-	}
-	return fetched
+func collectVersionImages(_ string, verData VersionResponse) []ModelImage {
+	return verData.Images
 }
 
 // SyncVersionByID imports a specific CivitAI model version identified by the

--- a/backend/api/types.go
+++ b/backend/api/types.go
@@ -56,13 +56,6 @@ type ModelImage struct {
 	Meta     map[string]interface{} `json:"meta"`
 }
 
-type imagesResponse struct {
-	Items    []ModelImage `json:"items"`
-	Metadata struct {
-		NextCursor string `json:"nextCursor"`
-	} `json:"metadata"`
-}
-
 // VersionInfo represents a simplified view of a model version returned to the frontend.
 // It contains the basic fields required for display and selection when downloading
 // a specific model version.


### PR DESCRIPTION
## Summary
- remove the CivitAI images endpoint fetch helper and rely on the model-version response for images
- simplify the image collection helper to return images already bundled with the version payload
- drop the unused paginated image response type

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4a5a690108332aa5edb74c2a68953