### PR TITLE
Add NSFW filter selector to model list

### DIFF
--- a/backend/api/handlers_list_test.go
+++ b/backend/api/handlers_list_test.go
@@ -72,11 +72,13 @@ func TestGetModelsAndCountFilters(t *testing.T) {
 		{"searchTrained", "?search=delta-key", []string{"Delta"}},
 		{"baseModel", "?baseModel=SD1", []string{"Beta", "Alpha"}},
 		{"modelType", "?modelType=lora", []string{"Delta", "Beta"}},
-		{"hideNsfw", "?hideNsfw=1", []string{"Delta", "Gamma", "Alpha"}},
+		{"nsfwNo", "?nsfwFilter=no", []string{"Delta", "Gamma", "Alpha"}},
+		{"nsfwOnly", "?nsfwFilter=only", []string{"Beta"}},
+		{"hideNsfwLegacy", "?hideNsfw=1", []string{"Delta", "Gamma", "Alpha"}},
 		{"tags", "?tags=tag3", []string{"Delta", "Beta"}},
 		{"multiTags", "?tags=tag1,tag2", []string{"Gamma"}},
 		{"combo", "?baseModel=SD2&modelType=checkpoint", []string{"Gamma"}},
-		{"comboNone", "?baseModel=SD1&modelType=lora&hideNsfw=1", []string{}},
+		{"comboNone", "?baseModel=SD1&modelType=lora&nsfwFilter=no", []string{}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- replace the model list NSFW toggle with a dropdown that supports No NSFW, Only NSFW, and Both options while persisting the selection
- update backend model list filtering to accept the new nsfwFilter query, keep legacy hideNsfw support, and adjust tests accordingly

## Testing
- go test ./...
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcbaf9fa288332a0f62b30e30bf75b