### PR TITLE
Add ability to cancel in-progress model downloads

### DIFF
--- a/backend/api/progress.go
+++ b/backend/api/progress.go
@@ -1,10 +1,30 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
 
 // GetDownloadProgress reports the global download progress percentage for
 // long-running model downloads. The endpoint accepts no parameters and simply
 // reads the package-level CurrentDownloadProgress value to return JSON.
 func GetDownloadProgress(c *gin.Context) {
 	c.JSON(200, gin.H{"progress": CurrentDownloadProgress})
+}
+
+// CancelDownload stops the active model download, if any, and cleans up any
+// partially written files. It responds with a success message regardless of
+// whether a download was in progress so the action remains idempotent.
+func CancelDownload(c *gin.Context) {
+	cancelled, err := CancelActiveDownload()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cancel download"})
+		return
+	}
+	if cancelled {
+		c.JSON(http.StatusOK, gin.H{"message": "Download cancelled"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "No active download"})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -37,6 +37,7 @@ func main() {
 		apiGroup.POST("/sync/:id", api.SyncCivitModelByID)
 		apiGroup.POST("/sync/version/:versionId", api.SyncVersionByID)
 		apiGroup.GET("/download/progress", api.GetDownloadProgress)
+		apiGroup.POST("/download/cancel", api.CancelDownload)
 		apiGroup.GET("/model/:id/versions", api.GetModelVersions)
 		apiGroup.GET("/versions/:id", api.GetVersion)
 		apiGroup.PUT("/versions/:id", api.UpdateVersion)


### PR DESCRIPTION
## Summary
- add backend support for canceling active downloads, including cleanup and a new API endpoint
- surface the cancel action in the Vue model list with button, state handling, and user feedback
- ensure download handlers detect cancellation and stop creating records for incomplete files

## Testing
- go test ./...
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1fc312708332bcb9fcb03ca45633